### PR TITLE
Set option "params['iscsi_lunid'] = 0" to make driver work with 11.2-u2

### DIFF
--- a/driver/ixsystems/common.py
+++ b/driver/ixsystems/common.py
@@ -96,6 +96,7 @@ class TrueNASCommon(object):
         params = {}
         params['iscsi_target'] = target_id
         params['iscsi_extent'] = extent_id
+        params['iscsi_lunid'] = 0
 
         LOG.debug('_create_target_to_extent params : %s', json.dumps(params))
 


### PR DESCRIPTION
This was found and reported by dleeshus on the freenas forums.

Tested with Openstack Queens on Centos and with freenas 11.1-u7 and 11.2-u2.