### PR TITLE
fix issue 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Here is an example configuration:
  [ixsystems-iscsi]
  iscsi_helper = tgtadm
  volume_dd_blocksize = 512
- volume_driver = cinder.volume.drivers.ixsystems.iscsi.FREENASISCSIDriver
+ volume_driver = cinder.volume.drivers.ixsystems.iscsi.FreeNASISCSIDriver
  ixsystems_login = root
  ixsystems_password = thisisdummypassword
  ixsystems_server_hostname = 100.1.2.34


### PR DESCRIPTION
This patch is to fix issue #4 to correct the README with the right class for the Freenas Cinder Driver