### PR TITLE
Fix pep8 failures.

### DIFF
--- a/driver/ixsystems/common.py
+++ b/driver/ixsystems/common.py
@@ -1,17 +1,32 @@
-#vim: tabstop=4 shiftwidth=4 softtabstop=4
-
 # Copyright (c) 2016 iXsystems
-from oslo_log import log as logging
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import os
+import simplejson as json
+import urllib.parse
+
 from cinder import exception
+from cinder.i18n import _
 from cinder.volume.drivers.ixsystems.freenasapi import FreeNASApiError
 from cinder.volume.drivers.ixsystems.freenasapi import FreeNASServer
-from oslo_config import cfg
-import os
-import urllib.parse
 from cinder.volume.drivers.ixsystems import utils as ix_utils
-import simplejson as json
+from oslo_config import cfg
+from oslo_log import log as logging
 
 LOG = logging.getLogger(__name__)
+CONF = cfg.CONF
 
 
 class TrueNASCommon(object):
@@ -22,54 +37,56 @@ class TrueNASCommon(object):
     required_flags = ['ixsystems_transport_type', 'ixsystems_login',
                       'ixsystems_password', 'ixsystems_server_hostname',
                       'ixsystems_server_port', 'ixsystems_server_iscsi_port',
-                      'ixsystems_volume_backend_name', 'ixsystems_vendor_name', 'ixsystems_storage_protocol',
-                      'ixsystems_datastore_pool', 'ixsystems_dataset_path', 'ixsystems_iqn_prefix', ]
+                      'ixsystems_volume_backend_name', 'ixsystems_vendor_name',
+                      'ixsystems_storage_protocol', 'ixsystems_datastore_pool',
+                      'ixsystems_dataset_path', 'ixsystems_iqn_prefix', ]
 
     def __init__(self, configuration=None):
-        self.configuration = configuration        
+        self.configuration = configuration
         self.backend_name = self.configuration.ixsystems_volume_backend_name
         self.vendor_name = self.configuration.ixsystems_vendor_name
         self.storage_protocol = self.configuration.ixsystems_storage_protocol
         self.stats = {}
 
     def _create_handle(self, **kwargs):
-        """Instantiate handle (client) for API communication with
-            iXsystems FREENAS server
-        """
+        """Instantiate client for API comms with iXsystems FREENAS server."""
+
         host_system = kwargs['hostname']
         LOG.debug('Using iXsystems FREENAS server: %s', host_system)
-        self.handle = FreeNASServer(host=host_system,
-                                 port=kwargs['port'],
-                                 username=kwargs['login'],
-                                 password=kwargs['password'],
-                                 api_version=kwargs['api_version'],
-                                 transport_type=kwargs['transport_type'],
-                                 style=FreeNASServer.STYLE_LOGIN_PASSWORD)
+        self.handle = FreeNASServer(
+            host=host_system,
+            port=kwargs['port'],
+            username=kwargs['login'],
+            password=kwargs['password'],
+            api_version=kwargs['api_version'],
+            transport_type=kwargs['transport_type'],
+            style=FreeNASServer.STYLE_LOGIN_PASSWORD)
         if not self.handle:
-            raise FreeNASApiError("Failed to create handle for FREENAS server")    
+            raise FreeNASApiError("Failed to create handle for FREENAS server")
 
     def _check_flags(self):
-        """Check if any required iXsystems FREENAS configuration flag is missing."""
+        """Check if any required iXsystems configuration flag is missing."""
         for flag in self.required_flags:
             if not getattr(self.configuration, flag, None):
-                print("missing flag :", flag)
                 raise exception.CinderException(_('%s is not set') % flag)
 
     def _do_custom_setup(self):
         """Setup iXsystems FREENAS driver."""
-        self._create_handle(hostname=self.configuration.ixsystems_server_hostname,
-                            port=self.configuration.ixsystems_server_port,
-                            login=self.configuration.ixsystems_login,
-                            password=self.configuration.ixsystems_password,
-                            api_version=self.configuration.ixsystems_api_version,
-                            transport_type=
-                            self.configuration.ixsystems_transport_type)
+        self._create_handle(
+            hostname=self.configuration.ixsystems_server_hostname,
+            port=self.configuration.ixsystems_server_port,
+            login=self.configuration.ixsystems_login,
+            password=self.configuration.ixsystems_password,
+            api_version=self.configuration.ixsystems_api_version,
+            transport_type=self.configuration.ixsystems_transport_type)
+
         if not self.handle:
-                raise FreeNASApiError("Failed to create handle for FREENAS server")
+            raise FreeNASApiError(
+                "Failed to create handle for FREENAS server")
 
     def _create_volume(self, name, size):
-        """Creates a volume of specified size
-        """
+        """Creates a volume of specified size."""
+
         params = {}
         params['name'] = self.configuration.ixsystems_dataset_path + '/' + name
         params['type'] = 'VOLUME'
@@ -87,9 +104,10 @@ class TrueNASCommon(object):
             raise FreeNASApiError('Unexpected error', msg)
 
     def _target_to_extent(self, target_id, extent_id):
-        """Create  relationship between iscsi target to iscsi extent"""
+        """Create relationship between iscsi target to iscsi extent."""
 
-        LOG.debug('_target_to_extent target id : %s extend id : %s', target_id, extent_id)
+        LOG.debug('_target_to_extent target id : %s extend id : %s',
+                  target_id, extent_id)
 
         request_urn = ('%s/') % (FreeNASServer.REST_API_TARGET_TO_EXTENT)
         params = {}
@@ -101,31 +119,40 @@ class TrueNASCommon(object):
 
         LOG.debug('_create_target_to_extent params : %s', json.dumps(params))
 
-        tgt_ext = self.handle.invoke_command(FreeNASServer.CREATE_COMMAND, request_urn, jparams)
+        tgt_ext = self.handle.invoke_command(FreeNASServer.CREATE_COMMAND,
+                                             request_urn, jparams)
 
         LOG.debug('_target_to_extent response : %s', json.dumps(tgt_ext))
 
         if tgt_ext['status'] != FreeNASServer.STATUS_OK:
-            msg = ('Error while creating relation between target and extent: %s' % tgt_ext['response'])
+            msg = ('Error while creating relation between '
+                   'target and extent: %s' % tgt_ext['response'])
             raise FreeNASApiError('Unexpected error', msg)
 
     def _create_target(self, name):
-        targetgroup_params = [{}] # v2.0 API - targetgroup can now be added when target is created
-        targetgroup_params[0]['portal'] = int(self.configuration.ixsystems_portal_id)  #TODO: Decide to create portal or not
-        targetgroup_params[0]['initiator'] = int(self.configuration.ixsystems_initiator_id) #TODO: Decide to create initiator or not
+        # v2.0 API - targetgroup can now be added when target is created
+        targetgroup_params = [{}]
+        # TODO: Decide to create portal or not
+        targetgroup_params[0]['portal'] = int(
+            self.configuration.ixsystems_portal_id)
+
+        # TODO: Decide to create initiator or not
+        targetgroup_params[0]['initiator'] = int(
+            self.configuration.ixsystems_initiator_id)
         tgt_params = {}
         tgt_params['name'] = name
-        tgt_params['groups'] = targetgroup_params 
+        tgt_params['groups'] = targetgroup_params
         jtgt_params = json.dumps(tgt_params)
         jtgt_params = jtgt_params.encode('utf8')
         LOG.debug('_create_target params : %s', json.dumps(tgt_params))
         request_urn = ('%s/') % (FreeNASServer.REST_API_TARGET)
         target = self.handle.invoke_command(FreeNASServer.CREATE_COMMAND,
-                                         request_urn, jtgt_params)
+                                            request_urn, jtgt_params)
         LOG.debug('_create_target response : %s', json.dumps(target))
 
         if target['status'] != FreeNASServer.STATUS_OK:
-            msg = ('Error while creating iscsi target: %s' % target['response'])
+            msg = ('Error while creating iscsi target: {}'.format(
+                target['response']))
             raise FreeNASApiError('Unexpected error', msg)
 
         target_id = json.loads(target['response'])['id']
@@ -133,71 +160,78 @@ class TrueNASCommon(object):
 
         return target_id
 
-    def _create_extent(self, name, volume_name,from_snapshot=False):
+    def _create_extent(self, name, volume_name, from_snapshot=False):
         ext_params = {}
         if from_snapshot:
             ext_params['Source'] = volume_name
         else:
             ext_params['type'] = 'DISK'
             ext_params['name'] = name
-        ext_params['disk'] = ('zvol/%s/%s') % (self.configuration.ixsystems_dataset_path, volume_name)
+        ext_params['disk'] = ('zvol/%s/%s') % (
+            self.configuration.ixsystems_dataset_path, volume_name)
         jext_params = json.dumps(ext_params)
         LOG.debug('_create_extent params : %s', jext_params)
         jext_params = jext_params.encode('utf8')
         request_urn = ('%s/') % (FreeNASServer.REST_API_EXTENT)
         extent = self.handle.invoke_command(FreeNASServer.CREATE_COMMAND,
-                                         request_urn, jext_params)
+                                            request_urn, jext_params)
 
         LOG.debug('_create_extent response : %s', json.dumps(extent))
 
         if extent['status'] != FreeNASServer.STATUS_OK:
-            msg = ('Error while creating iscsi target extent: %s' % extent['response'])
+            msg = ('Error while creating iscsi target extent: {}'.format(
+                extent['response']))
             raise FreeNASApiError('Unexpected error', msg)
 
         return json.loads(extent['response'])['id']
 
     def get_iscsitarget_id(self, name):
-        """get iscsi target id from target name
-        """
+        """get iscsi target id from target name."""
+
         request_urn = ('%s') % (FreeNASServer.REST_API_TARGET)
         LOG.debug('get_iscsitarget_id request_urn : %s', request_urn)
-        ret = self.handle.invoke_command(FreeNASServer.SELECT_COMMAND, request_urn, None)
+        ret = self.handle.invoke_command(FreeNASServer.SELECT_COMMAND,
+                                         request_urn, None)
         LOG.debug('get_iscsitarget_id response : %s', json.dumps(ret))
         if ret['status'] != FreeNASServer.STATUS_OK:
             msg = ('Error while deleting iscsi target: %s' % ret['response'])
             raise FreeNASApiError('Unexpected error', msg)
-        
+
         uresp = ret['response']
         resp = json.loads(uresp.decode('utf8'))
         try:
-            return (item for item in resp if item['name'] == name).__next__()['id']
+            return (item for item in resp
+                    if item['name'] == name).__next__()['id']
         except StopIteration:
             return 0
 
     def get_tgt_ext_id(self, name):
-        """Get target-extent mapping id from target name.
-        """
+        """Get target-extent mapping id from target name."""
+
         request_urn = ('%s') % (FreeNASServer.REST_API_TARGET_TO_EXTENT)
         LOG.debug('get_tgt_ext_id urn : %s', request_urn)
-        ret = self.handle.invoke_command(FreeNASServer.SELECT_COMMAND, request_urn, None)
+        ret = self.handle.invoke_command(FreeNASServer.SELECT_COMMAND,
+                                         request_urn, None)
         LOG.debug('get_tgt_ext_id response : %s', json.dumps(ret))
         if ret['status'] != FreeNASServer.STATUS_OK:
             msg = ('Error while deleting iscsi target: %s' % ret['response'])
             raise FreeNASApiError('Unexpected error', msg)
-        
+
         uresp = ret['response']
         resp = json.loads(uresp.decode('utf8'))
         try:
-            return (item for item in resp if item['target'] == name).__next__()['id']
+            return (item for item in resp
+                    if item['target'] == name).__next__()['id']
         except StopIteration:
             return 0
 
     def get_extent_id(self, name):
-        """Get Extent ID from Extent Name
-        """
+        """Get Extent ID from Extent Name."""
+
         request_urn = ('%s') % (FreeNASServer.REST_API_EXTENT)
         LOG.debug('get_extent_id urn : %s', request_urn)
-        ret = self.handle.invoke_command(FreeNASServer.SELECT_COMMAND, request_urn, None)
+        ret = self.handle.invoke_command(FreeNASServer.SELECT_COMMAND,
+                                         request_urn, None)
         LOG.debug('get_extent_id response : %s', json.dumps(ret))
         if ret['status'] != FreeNASServer.STATUS_OK:
             msg = ('Error while getting extent id: %s' % ret['response'])
@@ -206,67 +240,76 @@ class TrueNASCommon(object):
         uresp = ret['response']
         resp = json.loads(uresp.decode('utf8'))
         try:
-            return (item for item in resp if item['name'] == name).__next__()['id']
+            return (item for item in resp
+                    if item['name'] == name).__next__()['id']
         except StopIteration:
             return 0
 
     def _create_iscsitarget(self, name, volume_name):
-        """Creates a iSCSI target on specified volume OR snapshot
-        TODO : Skipped part for snapshot, review once iscsi target working
-        TODO: Add cleanup if any operation fails
+        """Creates a iSCSI target on specified volume OR snapshot.
+
+           TODO : Skipped part for snapshot, review once iscsi target working
+           TODO: Add cleanup if any operation fails
         """
 
-        #Create iscsi target for specified volume
+        # Create iscsi target for specified volume
         tgt_id = self._create_target(name)
 
-        #Create extent for iscsi target for specified volume
+        # Create extent for iscsi target for specified volume
         ext_id = self._create_extent(name, volume_name)
-     
-        #Create target to extent mapping for specified volume
+
+        # Create target to extent mapping for specified volume
         self._target_to_extent(tgt_id, ext_id)
 
     def delete_target_to_extent(self, tgt_ext_id):
         pass
-    
+
     def delete_target(self, target_id):
         if target_id:
-            request_urn = ('%s/id/%s') % (FreeNASServer.REST_API_TARGET, target_id)
+            request_urn = ('%s/id/%s') % (
+                FreeNASServer.REST_API_TARGET, target_id)
             LOG.debug('delete_target urn : %s', request_urn)
             ret = self.handle.invoke_command(FreeNASServer.DELETE_COMMAND,
-                                         request_urn, None)
+                                             request_urn, None)
             LOG.debug('delete_target response : %s', json.dumps(ret))
             if ret['status'] != FreeNASServer.STATUS_OK:
-                msg = ('Error while deleting iscsi target: %s' % ret['response'])
+                msg = (
+                    'Error while deleting iscsi target: %s' % ret['response'])
                 raise FreeNASApiError('Unexpected error', msg)
 
     def delete_extent(self, extent_id):
         if extent_id:
-            request_urn = ('%s/id/%s') % (FreeNASServer.REST_API_EXTENT, extent_id)
+            request_urn = ('%s/id/%s') % (
+                FreeNASServer.REST_API_EXTENT, extent_id)
             LOG.debug('delete_extent urn : %s', request_urn)
             ret = self.handle.invoke_command(FreeNASServer.DELETE_COMMAND,
-                                         request_urn, None)
+                                             request_urn, None)
             LOG.debug('delete_extent response : %s', json.dumps(ret))
             if ret['status'] != FreeNASServer.STATUS_OK:
-                msg = ('Error while deleting iscsi extent: %s' % ret['response'])
+                msg = (
+                    'Error while deleting iscsi extent: %s' % ret['response'])
                 raise FreeNASApiError('Unexpected error', msg)
 
     def _delete_iscsitarget(self, name):
-        """Deletes specified iSCSI target
-        """
+        """Deletes specified iSCSI target."""
         tgt_ext_id = self.get_tgt_ext_id(name)
         target_id = self.get_iscsitarget_id(name)
         extent_id = self.get_extent_id(name)
-        
+
         self.delete_target_to_extent(tgt_ext_id)
         self.delete_target(target_id)
         self.delete_extent(extent_id)
 
     def _dependent_clone(self, name):
-        """ returns the fullname of any snapshot used to create volume 'name' """
-        request_urn = ('%s/id/%s%s') % (FreeNASServer.REST_API_VOLUME, 
-                      urllib.parse.quote_plus(self.configuration.ixsystems_dataset_path + '/'), name)
+        """returns the fullname of snapshot used to create volume 'name'."""
+        request_urn = ('%s/id/%s%s') % (
+            FreeNASServer.REST_API_VOLUME,
+            urllib.parse.quote_plus(
+                self.configuration.ixsystems_dataset_path + '/'),
+            name)
         LOG.debug('_dependent_clones urn : %s', request_urn)
-        ret = self.handle.invoke_command(FreeNASServer.SELECT_COMMAND, request_urn, None)
+        ret = self.handle.invoke_command(FreeNASServer.SELECT_COMMAND,
+                                         request_urn, None)
         LOG.debug('_dependent_clones response : %s', json.dumps(ret))
         if ret['status'] != FreeNASServer.STATUS_OK:
             msg = ('Error while getting volume: %s' % ret['response'])
@@ -276,16 +319,22 @@ class TrueNASCommon(object):
         return resp['origin']['value']
 
     def _delete_volume(self, name):
-        """Deletes specified volume
-        """
-        request_urn = ('%s/id/%s%s') % (FreeNASServer.REST_API_VOLUME, 
-                      urllib.parse.quote_plus(self.configuration.ixsystems_dataset_path + '/'), name)
+        """Deletes specified volume."""
+        request_urn = ('%s/id/%s%s') % (
+            FreeNASServer.REST_API_VOLUME,
+            urllib.parse.quote_plus(
+                self.configuration.ixsystems_dataset_path + '/'),
+            name)
         LOG.debug('_delete_volume urn : %s', request_urn)
-        clone = self._dependent_clone(name) # add check for dependent clone, if exists will delete
+        # add check for dependent clone, if exists will delete
+        clone = self._dependent_clone(name)
         ret = self.handle.invoke_command(FreeNASServer.DELETE_COMMAND,
                                          request_urn, None)
         LOG.debug('_delete_volume response : %s', json.dumps(ret))
-        if clone: # delete the cloned-from snapshot.  Must check before deleting volume, but delete snapshot after
+
+        # delete the cloned-from snapshot.
+        # Must check before deleting volume, but delete snapshot after
+        if clone:
             fullvolume, snapname = clone.split('@')
             temp, snapvol = fullvolume.rsplit('/', 1)
             self._delete_snapshot(snapname, snapvol)
@@ -296,8 +345,9 @@ class TrueNASCommon(object):
     def _create_snapshot(self, name, volume_name):
         """Creates a snapshot of specified volume."""
         args = {}
-        args['dataset'] = ('%s/%s')  % (self.configuration.ixsystems_dataset_path, volume_name)
-        args['name'] =  name
+        args['dataset'] = ('%s/%s') % (
+            self.configuration.ixsystems_dataset_path, volume_name)
+        args['name'] = name
         jargs = json.dumps(args)
         jargs = jargs.encode("utf8")
         request_urn = ('%s') % (FreeNASServer.REST_API_SNAPSHOT)
@@ -315,9 +365,13 @@ class TrueNASCommon(object):
 
     def _delete_snapshot(self, name, volume_name):
         """Delets a snapshot of specified volume."""
-        LOG.debug('_delete_snapshot, deleting name: %s from volume: %s', name, volume_name)
-        request_urn = ('%s/id/%s@%s') % (FreeNASServer.REST_API_SNAPSHOT, 
-                      urllib.parse.quote_plus(self.configuration.ixsystems_dataset_path + '/' + volume_name), name)
+        LOG.debug('_delete_snapshot, deleting name: %s from volume: %s',
+                  name, volume_name)
+        request_urn = ('%s/id/%s@%s') % (
+            FreeNASServer.REST_API_SNAPSHOT,
+            urllib.parse.quote_plus(
+                self.configuration.ixsystems_dataset_path + '/' + volume_name),
+            name)
         LOG.debug('_delete_snapshot urn : %s', request_urn)
         try:
             ret = self.handle.invoke_command(FreeNASServer.DELETE_COMMAND,
@@ -329,63 +383,77 @@ class TrueNASCommon(object):
         except Exception as e:
             raise FreeNASApiError('Unexpected error', e)
 
-    def _create_volume_from_snapshot(self, name, snapshot_name, snap_zvol_name):
+    def _create_volume_from_snapshot(self, name, snapshot_name,
+                                     snap_zvol_name):
         """creates a volume from a snapshot"""
         args = {}
-        args['snapshot'] = ('%s/%s@%s')  % (self.configuration.ixsystems_dataset_path, snap_zvol_name, snapshot_name)
-        args['dataset_dst'] = ('%s/%s')  % (self.configuration.ixsystems_dataset_path, name)
+        args['snapshot'] = ('%s/%s@%s') % (
+            self.configuration.ixsystems_dataset_path,
+            snap_zvol_name,
+            snapshot_name)
+        args['dataset_dst'] = ('%s/%s') % (
+            self.configuration.ixsystems_dataset_path, name)
         jargs = json.dumps(args)
         jargs = jargs.encode("utf8")
-        request_urn = ('%s/%s') % (FreeNASServer.REST_API_SNAPSHOT, FreeNASServer.CLONE)
+        request_urn = ('%s/%s') % (
+            FreeNASServer.REST_API_SNAPSHOT, FreeNASServer.CLONE)
         LOG.debug('_create_volume_from_snapshot urn : %s', request_urn)
         try:
             ret = self.handle.invoke_command(FreeNASServer.CREATE_COMMAND,
                                              request_urn, jargs)
-            LOG.debug('_create_volume_from_snapshot response : %s', json.dumps(ret))
+            LOG.debug('_create_volume_from_snapshot response : %s',
+                      json.dumps(ret))
             if ret['status'] != FreeNASServer.STATUS_OK:
                 msg = ('Error while creating snapshot: %s' % ret['response'])
                 raise FreeNASApiError('Unexpected error', msg)
         except Exception as e:
             raise FreeNASApiError('Unexpected error', e)
 
-
     def _update_volume_stats(self):
-        """Retrieve stats info from volume group
-            REST API: $ GET /pools/mypool "size":95,"allocated":85,
+        """Retrieve stats info from volume group.
+
+           REST API: $ GET /pools/mypool "size":95,"allocated":85,
         """
-        # HACK: for now, use an API v1.0 call to get these stats until available in v2.0 API
+        # HACK: for now, use an API v1.0 call to get
+        # these stats until available in v2.0 API
         self.handle.set_api_version('v1.0')
-        request_urn = ('%s/%s/') % ('/storage/volume', self.configuration.ixsystems_datastore_pool)
+        request_urn = ('%s/%s/') % (
+            '/storage/volume',
+            self.configuration.ixsystems_datastore_pool)
         LOG.debug('_update_volume_stats request_urn : %s', request_urn)
         ret = self.handle.invoke_command(FreeNASServer.SELECT_COMMAND,
                                          request_urn, None)
         LOG.debug("_update_volume_stats response : %s", json.dumps(ret))
         data = {}
         data["volume_backend_name"] = self.backend_name
-        data["vendor_name"] =  self.vendor_name
+        data["vendor_name"] = self.vendor_name
         data["driver_version"] = self.VERSION
         data["storage_protocol"] = self.storage_protocol
-        data['total_capacity_gb'] = ix_utils.get_size_in_gb(json.loads(ret['response'])['avail'] + json.loads(ret['response'])['used'])
-        data['free_capacity_gb'] = ix_utils.get_size_in_gb(json.loads(ret['response'])['avail'])
-        data['reserved_percentage'] = \
-            self.configuration.ixsystems_reserved_percentage
+        data['total_capacity_gb'] = ix_utils.get_size_in_gb(
+            json.loads(ret['response'])['avail'] +
+            json.loads(ret['response'])['used'])
+        data['free_capacity_gb'] = ix_utils.get_size_in_gb(
+            json.loads(ret['response'])['avail'])
+        data['reserved_percentage'] = (
+            self.configuration.ixsystems_reserved_percentage)
         data['reserved_percentage'] = 0
         data['QoS_support'] = False
 
         self.stats = data
-        self.handle.set_api_version('v2.0') # set back to v2.0 api for other calls...
+        # set back to v2.0 api for other calls...
+        self.handle.set_api_version('v2.0')
         return self.stats
 
     def _create_cloned_volume_to_snapshot_map(self, volume_name, snapshot):
-        """ maintain a mapping between cloned volume and tempary snapshot"""
+        """maintain a mapping between cloned volume and tempary snapshot."""
         map_file = os.path.join(CONF.volumes_dir, volume_name)
         jparams = json.dumps(snapshot)
         try:
-             fd = open(map_file, 'w+')
-             fd.write(jparams)
-             fd.close()
+            fd = open(map_file, 'w+')
+            fd.write(jparams)
+            fd.close()
         except Exception as e:
-             LOG.error(_('_create_halo_volume_name_map: %s') % e)
+            LOG.error('_create_halo_volume_name_map: %s', e)
 
     def _extend_volume(self, name, new_size):
         """Extend an existing volumes size."""
@@ -394,19 +462,23 @@ class TrueNASCommon(object):
         params['volsize'] = ix_utils.get_bytes_from_gb(new_size)
         jparams = json.dumps(params)
         jparams = jparams.encode('utf8')
-        request_urn = ('%s/id/%s') % (FreeNASServer.REST_API_VOLUME, 
-                      urllib.parse.quote_plus(self.configuration.ixsystems_dataset_path + '/' + name))
+        request_urn = ('%s/id/%s') % (
+            FreeNASServer.REST_API_VOLUME,
+            urllib.parse.quote_plus(
+                self.configuration.ixsystems_dataset_path + '/' + name))
         ret = self.handle.invoke_command(FreeNASServer.UPDATE_COMMAND,
                                          request_urn, jparams)
         if ret['status'] != FreeNASServer.STATUS_OK:
             msg = ('Error while extending volume: %s' % ret['response'])
             raise FreeNASApiError('Unexpected error', msg)
 
-
     def _create_export(self, volume_name):
-        freenas_volume = ix_utils.generate_freenas_volume_name(volume_name, self.configuration.ixsystems_iqn_prefix)
+        freenas_volume = ix_utils.generate_freenas_volume_name(
+            volume_name,
+            self.configuration.ixsystems_iqn_prefix)
+
         if freenas_volume is None:
-            LOG.error(_('Error in exporting FREENAS volume!'))
+            LOG.error('Error in exporting FREENAS volume!')
             handle = None
         else:
             handle = "%s:%s,%s %s" % \

--- a/driver/ixsystems/freenasapi.py
+++ b/driver/ixsystems/freenasapi.py
@@ -1,17 +1,30 @@
-# vim: tabstop=4 shiftwidth=4 softtabstop=4
-
 # Copyright (c) 2016 iXsystems
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
 """
 FREENAS api for iXsystems FREENAS system.
 
 Contains classes required to issue REST based api calls to FREENAS system.
 """
 
-#from cinder.openstack.common import jsonutils
-from oslo_log import log as logging
-import urllib.request, urllib.error, urllib.parse
-import simplejson as json
 import base64
+import simplejson as json
+
+from oslo_log import log as logging
+import urllib.error
+import urllib.parse
+import urllib.request
 
 LOG = logging.getLogger(__name__)
 
@@ -37,7 +50,7 @@ class FreeNASServer(object):
     # REST_API_TARGET_GROUP = "/services/iscsi/targetgroup/"
     REST_API_SNAPSHOT = "/zfs/snapshot"
     ZVOLS = "zvols"
-    TARGET_ID = -1 #We assume invalid id to begin with
+    TARGET_ID = -1  # We assume invalid id to begin with
     STORAGE_TABLE = "/storage"
     CLONE = "clone"
     # Command response format
@@ -99,6 +112,7 @@ class FreeNASServer(object):
 
     def set_style(self, style):
         """Set the authorization style for communicating with the server.
+
            Supports basic_auth for now.
         """
         if style.lower() not in (FreeNASServer.STYLE_LOGIN_PASSWORD):
@@ -106,14 +120,13 @@ class FreeNASServer(object):
         self._auth_style = style.lower()
 
     def get_url(self):
-        """Returns connection string built using _protocol, _host,
-           _port and _api_version fields
+        """Returns connection string.
+
+           built using _protocol, _host, _port and _api_version fields
         """
         return '%s://%s/api/%s' % (self._protocol,
-                                      self._host,
-                                      self._api_version)
-
-
+                                   self._host,
+                                   self._api_version)
 
     def _create_request(self, request_d, param_list):
         """Creates urllib2.Request object."""
@@ -144,7 +157,9 @@ class FreeNASServer(object):
             return None
 
     def _parse_result(self, command_d, response_d):
-        """parses the response upon execution of FREENAS API. COMMAND_RESPONSE is
+        """parses the response upon execution of FREENAS API.
+
+           COMMAND_RESPONSE is
            the dictionary object with status and response fields.
            If error, set status to ERROR else set it to OK
         """
@@ -190,10 +205,13 @@ class FreeNASServer(object):
         try:
             response_d = urllib.request.urlopen(request)
             response = self._parse_result(command_d, response_d)
-            LOG.debug("invoke_command : response for request %s : %s", request_d, json.dumps(response))
+            LOG.debug("invoke_command : response for request %s : %s",
+                      request_d, json.dumps(response))
         except urllib.error.HTTPError as e:
-            # LOG the error message received from FreeNAS/TrueNAS: https://github.com/iXsystems/cinder/issues/11
-            LOG.info('Error returned from server: "%s"', json.loads(e.read().decode('utf8'))['message'])
+            # LOG the error message received from FreeNAS/TrueNAS:
+            # https://github.com/iXsystems/cinder/issues/11
+            LOG.info('Error returned from server: "%s"',
+                     json.loads(e.read().decode('utf8'))['message'])
             error_d = self._get_error_info(e)
             if error_d:
                 return error_d

--- a/driver/ixsystems/iscsi.py
+++ b/driver/ixsystems/iscsi.py
@@ -1,32 +1,34 @@
-#vim: tabstop=4 shiftwidth=4 softtabstop=4
-
 # Copyright (c) 2016 iXsystems
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
 """
 Volume driver for iXsystems iSCSI storage systems.
 
 This driver requires iXsystems storage systems with installed iSCSI licenses.
 """
 
+import simplejson as json
 
-from cinder import exception
-from cinder.image import image_utils
-from cinder import utils
-from oslo_log import log as logging
 from cinder.volume import driver
-from cinder.volume.drivers.ixsystems.freenasapi import FreeNASApiError
-from cinder.volume.drivers.ixsystems.freenasapi import FreeNASServer
+from cinder.volume.drivers.ixsystems import common
 from cinder.volume.drivers.ixsystems.options import ixsystems_basicauth_opts
 from cinder.volume.drivers.ixsystems.options import ixsystems_connection_opts
 from cinder.volume.drivers.ixsystems.options import ixsystems_provisioning_opts
 from cinder.volume.drivers.ixsystems.options import ixsystems_transport_opts
-from cinder.volume.drivers.ixsystems import common
-from cinder.volume import volume_utils
 from cinder.volume.drivers.ixsystems import utils as ix_utils
-from cinder.i18n import _
-from lxml import etree
-import os
 from oslo_config import cfg
-import simplejson as json
+from oslo_log import log as logging
 
 LOG = logging.getLogger(__name__)
 
@@ -42,16 +44,17 @@ class FreeNASISCSIDriver(driver.ISCSIDriver):
 
     VERSION = "2.0.0"
     IGROUP_PREFIX = 'openstack-'
-    
+
     required_flags = ['ixsystems_transport_type', 'ixsystems_login',
                       'ixsystems_password', 'ixsystems_server_hostname',
                       'ixsystems_server_port', 'ixsystems_server_iscsi_port',
-                      'ixsystems_volume_backend_name', 'ixsystems_vendor_name', 'ixsystems_storage_protocol',
-                      'ixsystems_datastore_pool', 'ixsystems_dataset_path', 'ixsystems_iqn_prefix', ]
+                      'ixsystems_volume_backend_name', 'ixsystems_vendor_name',
+                      'ixsystems_storage_protocol', 'ixsystems_datastore_pool',
+                      'ixsystems_dataset_path', 'ixsystems_iqn_prefix', ]
 
     def __init__(self, *args, **kwargs):
         """Initialize FreeNASISCSIDriver Class."""
-        """ Set logging to debug """
+
         LOG.info('iXsystems: Init Cinder Driver')
         super(FreeNASISCSIDriver, self).__init__(*args, **kwargs)
         self.configuration.append_config_values(ixsystems_connection_opts)
@@ -62,19 +65,19 @@ class FreeNASISCSIDriver(driver.ISCSIDriver):
         self.common = common.TrueNASCommon(configuration=self.configuration)
         self.stats = {}
 
-
     def check_for_setup_error(self):
         """Check for iXsystems FREENAS configuration parameters."""
         LOG.info('iXSystems: Check For Setup Error')
         self.common._check_flags()
 
     def do_setup(self, context):
-        """Setup iXsystems FREENAS driver
+        """Setup iXsystems FREENAS driver.
+
             Check for configuration flags and setup iXsystems FREENAS client
         """
         LOG.info('iXsystems Do Setup')
-        #TODO:add check to see if volume exist, able to connect
-        #truenas array
+        # TODO:add check to see if volume exist, able to connect
+        # truenas array
         self.check_for_setup_error()
         self.common._do_custom_setup()
 
@@ -83,32 +86,35 @@ class FreeNASISCSIDriver(driver.ISCSIDriver):
         LOG.info('iXsystems Create Volume')
         LOG.debug('create_volume : volume name :: %s', volume['name'])
 
-        freenas_volume = ix_utils.generate_freenas_volume_name(volume['name'],
-						self.configuration.ixsystems_iqn_prefix)
-        
-        LOG.debug('volume name after freenas generate : %s', json.dumps(freenas_volume))
+        freenas_volume = ix_utils.generate_freenas_volume_name(
+            volume['name'],
+            self.configuration.ixsystems_iqn_prefix)
+
+        LOG.debug('volume name after freenas generate : %s',
+                  json.dumps(freenas_volume))
 
         freenas_volume['size'] = volume['size']
         freenas_volume['target_size'] = volume['size']
 
-        self.common._create_volume(freenas_volume['name'], freenas_volume['size'])
-        #Remove LUN Creation from here,check at initi
-        self.common._create_iscsitarget(freenas_volume['target'], 
+        self.common._create_volume(freenas_volume['name'],
+                                   freenas_volume['size'])
+        # Remove LUN Creation from here,check at initi
+        self.common._create_iscsitarget(freenas_volume['target'],
                                         freenas_volume['name'])
-
 
     def delete_volume(self, volume):
         """Deletes volume and corresponding iscsi target."""
         LOG.info('iXsystems Delete Volume')
         LOG.debug('delete_volume %s', volume['name'])
 
-        freenas_volume = ix_utils.generate_freenas_volume_name(volume['name'], self.configuration.ixsystems_iqn_prefix)
+        freenas_volume = ix_utils.generate_freenas_volume_name(
+            volume['name'],
+            self.configuration.ixsystems_iqn_prefix)
 
         if freenas_volume['target']:
             self.common._delete_iscsitarget(freenas_volume['target'])
         if freenas_volume['name']:
             self.common._delete_volume(freenas_volume['name'])
-
 
     def create_export(self, context, volume, connector):
         """Driver entry point to get the export info for a new volume."""
@@ -130,26 +136,32 @@ class FreeNASISCSIDriver(driver.ISCSIDriver):
 
     def remove_export(self, context, volume):
         """Driver exntry point to remove an export for a volume.
-            we have nothing to do for unexporting.
+
+           we have nothing to do for unexporting.
         """
         pass
 
     def initialize_connection(self, volume, connector):
         """Driver entry point to attach a volume to an instance."""
         LOG.info('iXsystems Initialise Connection')
-        freenas_volume = ix_utils.generate_freenas_volume_name(volume['name'],self.configuration.ixsystems_iqn_prefix)
+        freenas_volume = ix_utils.generate_freenas_volume_name(
+            volume['name'],
+            self.configuration.ixsystems_iqn_prefix)
+
         if not freenas_volume['name']:
             # is this snapshot?
-            freenas_volume = ix_utils.generate_freenas_snapshot_name(volume['name'],self.configuration.ixsystems_iqn_prefix)
+            freenas_volume = ix_utils.generate_freenas_snapshot_name(
+                volume['name'],
+                self.configuration.ixsystems_iqn_prefix)
 
-        LOG.info('initialize_connection Entry: %s \t %s', volume['name'], connector['host'])
         properties = {}
         properties['target_discovered'] = False
-        properties['target_portal'] = ix_utils.get_iscsi_portal(self.configuration.ixsystems_server_hostname,
-						self.configuration.ixsystems_server_iscsi_port)
+        properties['target_portal'] = ix_utils.get_iscsi_portal(
+            self.configuration.ixsystems_server_hostname,
+            self.configuration.ixsystems_server_iscsi_port)
         properties['target_iqn'] = freenas_volume['iqn']
         properties['volume_id'] = volume['id']
-        
+
         LOG.debug('initialize_connection data: %s', properties)
         return {'driver_volume_type': 'iscsi', 'data': properties}
 
@@ -161,36 +173,48 @@ class FreeNASISCSIDriver(driver.ISCSIDriver):
         """Driver entry point for creating a snapshot."""
         LOG.info('iXsystems Create Snapshot')
         LOG.debug('create_snapshot %s', snapshot['name'])
-        
-        freenas_snapshot = ix_utils.generate_freenas_snapshot_name(snapshot['name'], self.configuration.ixsystems_iqn_prefix)
-        freenas_volume = ix_utils.generate_freenas_volume_name(snapshot['volume_name'], self.configuration.ixsystems_iqn_prefix)
 
-        self.common._create_snapshot(freenas_snapshot['name'], freenas_volume['name'])
+        freenas_snapshot = ix_utils.generate_freenas_snapshot_name(
+            snapshot['name'], self.configuration.ixsystems_iqn_prefix)
+        freenas_volume = ix_utils.generate_freenas_volume_name(
+            snapshot['volume_name'], self.configuration.ixsystems_iqn_prefix)
+
+        self.common._create_snapshot(freenas_snapshot['name'],
+                                     freenas_volume['name'])
 
     def delete_snapshot(self, snapshot):
         """Driver entry point for deleting a snapshot."""
         LOG.info('iXsystems Delete Snapshot')
         LOG.debug('delete_snapshot %s', snapshot['name'])
-        freenas_snapshot = ix_utils.generate_freenas_snapshot_name(snapshot['name'],self.configuration.ixsystems_iqn_prefix)
-        freenas_volume = ix_utils.generate_freenas_volume_name(snapshot['volume_name'],self.configuration.ixsystems_iqn_prefix)
-        
-        self.common._delete_snapshot(freenas_snapshot['name'], freenas_volume['name'])
-    
+        freenas_snapshot = ix_utils.generate_freenas_snapshot_name(
+            snapshot['name'],
+            self.configuration.ixsystems_iqn_prefix)
+        freenas_volume = ix_utils.generate_freenas_volume_name(
+            snapshot['volume_name'],
+            self.configuration.ixsystems_iqn_prefix)
+
+        self.common._delete_snapshot(freenas_snapshot['name'],
+                                     freenas_volume['name'])
+
     def create_volume_from_snapshot(self, volume, snapshot):
         """Creates a volume from snapshot."""
         LOG.info('iXsystems Create Volume From Snapshot')
         LOG.info('create_volume_from_snapshot %s', snapshot['name'])
 
-        existing_vol = ix_utils.generate_freenas_volume_name(snapshot['volume_name'],self.configuration.ixsystems_iqn_prefix)
-        freenas_snapshot = ix_utils.generate_freenas_snapshot_name(snapshot['name'],self.configuration.ixsystems_iqn_prefix)
-        freenas_volume = ix_utils.generate_freenas_volume_name(volume['name'],self.configuration.ixsystems_iqn_prefix)
+        existing_vol = ix_utils.generate_freenas_volume_name(
+            snapshot['volume_name'], self.configuration.ixsystems_iqn_prefix)
+        freenas_snapshot = ix_utils.generate_freenas_snapshot_name(
+            snapshot['name'], self.configuration.ixsystems_iqn_prefix)
+        freenas_volume = ix_utils.generate_freenas_volume_name(
+            volume['name'], self.configuration.ixsystems_iqn_prefix)
         freenas_volume['size'] = volume['size']
         freenas_volume['target_size'] = volume['size']
 
-        self.common._create_volume_from_snapshot(freenas_volume['name'], freenas_snapshot['name'], existing_vol['name'])
+        self.common._create_volume_from_snapshot(freenas_volume['name'],
+                                                 freenas_snapshot['name'],
+                                                 existing_vol['name'])
         self.common._create_iscsitarget(freenas_volume['target'],
                                         freenas_volume['name'])
-
 
     def get_volume_stats(self, refresh=False):
         """Get stats info from volume group / pool."""
@@ -200,29 +224,31 @@ class FreeNASISCSIDriver(driver.ISCSIDriver):
         LOG.info('get_volume_stats: %s', self.stats)
         return self.stats
 
-
     def create_cloned_volume(self, volume, src_vref):
         """Creates a volume from source volume."""
         LOG.info('iXsystems Create Cloned Volume')
         LOG.info('create_cloned_volume: %s', src_vref['id'])
 
-        context = None
         temp_snapshot = {'volume_name': src_vref['name'],
                          'name': 'name-c%s' % src_vref['id']}
-        
+
         self.create_snapshot(temp_snapshot)
         self.create_volume_from_snapshot(volume, temp_snapshot)
         # self.delete_snapshot(temp_snapshot)
-        # with API v2.0 this causes FreeNAS error "snapshot has dependent clones".  Cannot delete while volume is active.
-        # Instead, added check and deletion of orphaned dependent clones in common._delete_volume()
+        # with API v2.0 this causes FreeNAS error
+        # "snapshot has dependent clones".  Cannot delete while volume is
+        # active.  Instead, added check and deletion of orphaned dependent
+        # clones in common._delete_volume()
 
     def extend_volume(self, volume, new_size):
         """Driver entry point to extend an existing volumes size."""
         LOG.info('iXsystems Extent Volume')
         LOG.info('extend_volume %s', volume['name'])
-        
-        freenas_volume = ix_utils.generate_freenas_volume_name(volume['name'],self.configuration.ixsystems_iqn_prefix) 
+
+        freenas_volume = ix_utils.generate_freenas_volume_name(
+            volume['name'], self.configuration.ixsystems_iqn_prefix)
         freenas_new_size = new_size
-        
+
         if volume['size'] != freenas_new_size:
-            self.common._extend_volume(freenas_volume['name'], freenas_new_size)
+            self.common._extend_volume(freenas_volume['name'],
+                                       freenas_new_size)

--- a/driver/ixsystems/options.py
+++ b/driver/ixsystems/options.py
@@ -1,10 +1,22 @@
-# vim: tabstop=4 shiftwidth=4 softtabstop=4
-
 # Copyright (c) 2016 iXsystems
-
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
 """Contains configuration options for iXsystems Cinder drivers."""
 
+
 from oslo_config import cfg
+
 
 ixsystems_connection_opts = [
     cfg.StrOpt('ixsystems_server_hostname',
@@ -21,7 +33,7 @@ ixsystems_connection_opts = [
                help='FREENAS API version'),
     cfg.StrOpt('ixsystems_volume_backend_name',
                default='iXsystems_FREENAS_Storage',
-               help='Backend Storage Controller Name'), 
+               help='Backend Storage Controller Name'),
     cfg.StrOpt('ixsystems_vendor_name',
                default='iXsystem',
                help='vendor name on Storage controller'),
@@ -55,7 +67,7 @@ ixsystems_provisioning_opts = [
                help='Reserved space on Storage controller'),
     cfg.StrOpt('ixsystems_iqn_prefix',
                default='iqn.2005-10.org.freenas.ctl',
-               help='Storage controller iSCSI Qualified Name prefix'), 
+               help='Storage controller iSCSI Qualified Name prefix'),
     cfg.StrOpt('ixsystems_portal_id',
                default=1,
                help='Storage controller iSCSI portal ID'),

--- a/driver/ixsystems/utils.py
+++ b/driver/ixsystems/utils.py
@@ -1,28 +1,46 @@
-#vim: tabstop=4 shiftwidth=4 softtabstop=4
-
 # Copyright (c) 2016 iXsystems
-import six
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+
 def get_size_in_gb(size_in_bytes):
     """convert size in gbs"""
-    return size_in_bytes/(1024*1024*1024)
+    return size_in_bytes / (1024 * 1024 * 1024)
+
 
 def get_bytes_from_gb(size_in_gb):
-    """ Convert size from GB into bytes """
-    return size_in_gb*(1024*1024*1024)
+    """Convert size from GB into bytes."""
+    return size_in_gb * (1024 * 1024 * 1024)
+
 
 def generate_freenas_volume_name(name, iqn_prefix):
     """Create FREENAS volume / iscsitarget name from Cinder name."""
     backend_volume = 'volume-' + name.split('-')[1]
     backend_target = 'target-' + name.split('-')[1]
     backend_iqn = iqn_prefix + backend_target
-    return {'name': backend_volume, 'target': backend_target, 'iqn': backend_iqn}
+    return {'name': backend_volume,
+            'target': backend_target, 'iqn': backend_iqn}
+
 
 def generate_freenas_snapshot_name(name, iqn_prefix):
     """Create FREENAS snapshot / iscsitarget name from Cinder name."""
     backend_snap = 'snap-' + name.split('-')[1]
     backend_target = 'target-' + name.split('-')[1]
     backend_iqn = iqn_prefix + backend_target
-    return {'name': backend_snap, 'target': backend_target, 'iqn': backend_iqn}
+    return {'name': backend_snap,
+            'target': backend_target, 'iqn': backend_iqn}
+
 
 def get_iscsi_portal(hostname, port):
     """Get iscsi portal info from iXsystems FREENAS configuration."""


### PR DESCRIPTION
This patch fixes the pep8 failures while running cinder's tox -epep8
to ensure the code meets the standards for the openstack cinder project.

TODO: still need unit tests to get acceptance into cinder