### PR TITLE
New implementation for function _update_volume_stats using v2.0 API for truenas

### DIFF
--- a/driver/ixsystems/common.py
+++ b/driver/ixsystems/common.py
@@ -409,40 +409,83 @@ class TrueNASCommon(object):
         except Exception as e:
             raise FreeNASApiError('Unexpected error', e)
 
+    def _system_version(self):
+            LOG.debug('_update_volume_stats start /system/version request')
+            request_urn = ("/system/version")
+            self.handle.set_api_version('v2.0')
+            versionresult=""
+            try:
+                versionret = self.handle.invoke_command(FreeNASServer.SELECT_COMMAND,
+                                                request_urn, None)
+                LOG.debug('_update_volume_stats start /system/version response: %s',versionret)
+                versionresult = json.loads(versionret['response'])
+                LOG.debug('_update_volume_stats /system/version response : %s', versionresult)
+                LOG.debug('_update_volume_stats _get_system_version return : %s', str(versionresult))
+            except Exception as e:
+                raise FreeNASApiError('Unexpected error', e)
+            finally:
+                return str(versionresult)
+            
     def _update_volume_stats(self):
-        """Retrieve stats info from volume group.
-
-           REST API: $ GET /pools/mypool "size":95,"allocated":85,
-        """
-        # HACK: for now, use an API v1.0 call to get
-        # these stats until available in v2.0 API
-        self.handle.set_api_version('v1.0')
-        request_urn = ('%s/%s/') % (
-            '/storage/volume',
-            self.configuration.ixsystems_datastore_pool)
-        LOG.debug('_update_volume_stats request_urn : %s', request_urn)
-        ret = self.handle.invoke_command(FreeNASServer.SELECT_COMMAND,
-                                         request_urn, None)
-        LOG.debug("_update_volume_stats response : %s", json.dumps(ret))
         data = {}
-        data["volume_backend_name"] = self.backend_name
-        data["vendor_name"] = self.vendor_name
-        data["driver_version"] = self.VERSION
-        data["storage_protocol"] = self.storage_protocol
-        data['total_capacity_gb'] = ix_utils.get_size_in_gb(
-            json.loads(ret['response'])['avail'] +
-            json.loads(ret['response'])['used'])
-        data['free_capacity_gb'] = ix_utils.get_size_in_gb(
-            json.loads(ret['response'])['avail'])
-        data['reserved_percentage'] = (
-            self.configuration.ixsystems_reserved_percentage)
-        data['reserved_percentage'] = 0
-        data['QoS_support'] = False
+        # Implementation for Freenas on API V1.0
+        # Truenas core and scale use API v2.0 
+        if self._system_version().find("FreeNAS")>=0:
+            self.handle.set_api_version('v1.0')
+            request_urn = ('%s/%s/') % (
+                '/storage/volume',
+                self.configuration.ixsystems_datastore_pool)
+            LOG.debug('_update_volume_stats request_urn : %s', request_urn)
+            ret = self.handle.invoke_command(FreeNASServer.SELECT_COMMAND,
+                                            request_urn, None)
+            LOG.debug("_update_volume_stats response : %s", json.dumps(ret))
+            data = {}
+            data["volume_backend_name"] = self.backend_name
+            data["vendor_name"] = self.vendor_name
+            data["driver_version"] = self.VERSION
+            data["storage_protocol"] = self.storage_protocol
+            data['total_capacity_gb'] = ix_utils.get_size_in_gb(
+                json.loads(ret['response'])['avail'] +
+                json.loads(ret['response'])['used'])
+            data['free_capacity_gb'] = ix_utils.get_size_in_gb(
+                json.loads(ret['response'])['avail'])
+            data['reserved_percentage'] = (
+                self.configuration.ixsystems_reserved_percentage)
+            data['reserved_percentage'] = 0
+            data['QoS_support'] = False            
+            self.handle.set_api_version('v2.0')
+
+        else:
+            """Retrieve dataset available and used using API 2.0 /pool/dataset/id/$id instead of API 1.0. This enable support for Truenas core/Truenas scale.
+
+            REST API: $ GET /pool/dataset/id/$id retrive available and used parsed value for id matching config file 'ixsystems_dataset_path'
+            """        
+            self.handle.set_api_version('v2.0')
+            request_urn = ('%s%s') % ('/pool/dataset/id/',urllib.parse.quote_plus(self.configuration.ixsystems_dataset_path))
+            LOG.info('_update_volume_stats request_urn : %s', request_urn)
+            ret = self.handle.invoke_command(FreeNASServer.SELECT_COMMAND,
+                                            request_urn, None)
+            LOG.info("_update_volume_stats response : %s", json.dumps(ret))
+            retresult = json.loads(ret['response'])
+            avail = retresult['available']['parsed']
+            used = retresult['used']['parsed']     
+            LOG.info('_update_volume_stats avail : %s', avail)
+            LOG.info('_update_volume_stats used : %s', used)
+            data["volume_backend_name"] = self.backend_name
+            data["vendor_name"] = self.vendor_name
+            data["driver_version"] = self.VERSION
+            data["storage_protocol"] = self.storage_protocol
+            data['total_capacity_gb'] = ix_utils.get_size_in_gb(avail+used)
+            data['free_capacity_gb'] = ix_utils.get_size_in_gb(avail)
+            data['reserved_percentage'] = (
+                self.configuration.ixsystems_reserved_percentage)
+            data['reserved_percentage'] = 0
+            data['QoS_support'] = False
 
         self.stats = data
-        # set back to v2.0 api for other calls...
-        self.handle.set_api_version('v2.0')
         return self.stats
+
+
 
     def _create_cloned_volume_to_snapshot_map(self, volume_name, snapshot):
         """maintain a mapping between cloned volume and tempary snapshot."""

--- a/driver/ixsystems/common.py
+++ b/driver/ixsystems/common.py
@@ -411,9 +411,12 @@ class TrueNASCommon(object):
 
     def _system_version(self):
             LOG.debug('_update_volume_stats start /system/version request')
+            # Use API v2.0 /system/version to detect nasversion
+            # API v2.0 /system/version available for FreeNAS 11.x TrueNAS 12.x TrueNAS 13.x TrueNAS Scale 22.x
             request_urn = ("/system/version")
             self.handle.set_api_version('v2.0')
-            versionresult=""
+            # For legacy verion that does not support API v2.0 /system/version return fallback value "VersionNotFound"
+            versionresult="VersionNotFound"
             try:
                 versionret = self.handle.invoke_command(FreeNASServer.SELECT_COMMAND,
                                                 request_urn, None)
@@ -427,9 +430,10 @@ class TrueNASCommon(object):
             
     def _update_volume_stats(self):
         data = {}
+        nasversion = self._system_version()
         # Implementation for TrueNAS 12.0 upwards on API V2.0
         # If user are connecting to FreeNAS report error
-        if self._system_version().find("FreeNAS")>=0:
+        if nasversion.find("FreeNAS")>=0 or nasversion=="VersionNotFound" :
             LOG.error("FreeNAS is no longer support by this version of cinder driver.")
             raise FreeNASApiError('Version not supported','FreeNAS is no longer support by this version of cinder driver.')
         else:

--- a/driver/ixsystems/common.py
+++ b/driver/ixsystems/common.py
@@ -420,7 +420,6 @@ class TrueNASCommon(object):
                 LOG.debug('_update_volume_stats start /system/version response: %s',versionret)
                 versionresult = json.loads(versionret['response'])
                 LOG.debug('_update_volume_stats /system/version response : %s', versionresult)
-                LOG.debug('_update_volume_stats _get_system_version return : %s', str(versionresult))
             except Exception as e:
                 raise FreeNASApiError('Unexpected error', e)
             finally:
@@ -428,36 +427,13 @@ class TrueNASCommon(object):
             
     def _update_volume_stats(self):
         data = {}
-        # Implementation for Freenas on API V1.0
-        # Truenas core and scale use API v2.0 
+        # Implementation for TrueNAS 12.0 upwards on API V2.0
+        # If user are connecting to FreeNAS report error
         if self._system_version().find("FreeNAS")>=0:
-            self.handle.set_api_version('v1.0')
-            request_urn = ('%s/%s/') % (
-                '/storage/volume',
-                self.configuration.ixsystems_datastore_pool)
-            LOG.debug('_update_volume_stats request_urn : %s', request_urn)
-            ret = self.handle.invoke_command(FreeNASServer.SELECT_COMMAND,
-                                            request_urn, None)
-            LOG.debug("_update_volume_stats response : %s", json.dumps(ret))
-            data = {}
-            data["volume_backend_name"] = self.backend_name
-            data["vendor_name"] = self.vendor_name
-            data["driver_version"] = self.VERSION
-            data["storage_protocol"] = self.storage_protocol
-            data['total_capacity_gb'] = ix_utils.get_size_in_gb(
-                json.loads(ret['response'])['avail'] +
-                json.loads(ret['response'])['used'])
-            data['free_capacity_gb'] = ix_utils.get_size_in_gb(
-                json.loads(ret['response'])['avail'])
-            data['reserved_percentage'] = (
-                self.configuration.ixsystems_reserved_percentage)
-            data['reserved_percentage'] = 0
-            data['QoS_support'] = False            
-            self.handle.set_api_version('v2.0')
-
+            LOG.error("FreeNAS is no longer support by this version of cinder driver.")
+            raise FreeNASApiError('Version not supported','FreeNAS is no longer support by this version of cinder driver.')
         else:
             """Retrieve dataset available and used using API 2.0 /pool/dataset/id/$id instead of API 1.0. This enable support for Truenas core/Truenas scale.
-
             REST API: $ GET /pool/dataset/id/$id retrive available and used parsed value for id matching config file 'ixsystems_dataset_path'
             """        
             self.handle.set_api_version('v2.0')


### PR DESCRIPTION
New implementation for function _update_volume_stats uses v2.0 API, this provides driver support for TrueNAS 12/13 and TrueNAS scale 22.0. Add system version check to ensure when driver loaded on FreeNAS proper error handling and inform users this version of driver no longer supports FreeNAS.

Tested on my local environments:

- FreeNAS-11.3-RELEASE (Inform user driver no longer support Freenas)
- TrueNAS-12.0-U8.1 (working)
- TrueNAS-13.0-U2 (working)
- TrueNAS-SCALE-22.02.1 (working)

Test case cover: create volume, delete volume, create iscsi target, delete iscsi target, update volume stats.