### PR TITLE
#27 fix , #23 pep8 compliance and minor fix. 

### DIFF
--- a/driver/ixsystems/iscsi.py
+++ b/driver/ixsystems/iscsi.py
@@ -149,20 +149,25 @@ class FreeNASISCSIDriver(driver.ISCSIDriver):
     def check_connection(self):
         # connection safety check for #27
         if ix_utils.parse_truenas_version(self.common._system_version())[1] in ('12.0', '13.0'):
-            LOG.debug("Tanable: %s" % str(self.common._tunable()))
+            LOG.debug("Tanable: %s", str(self.common._tunable()))
             tunable = self.common._tunable()
-            # default value from Truenas 12 kern.cam.ctl.max_ports 256, kern.cam.ctl.max_luns 1024
-            lunallowed = 256
+            # Default value from Truenas 12 kern.cam.ctl.max_ports 256, kern.cam.ctl.max_luns 1024
+            # common._tunable() returns a list of dict [{'var':'kern.cam.ctl.max_luns','enabled':True,'value':'256'}
+            # ,{'var':'kern.cam.ctl.max_ports','enabled':True,'value':'1024'}]
+            # Retrive attach_max_allow from min value of common._tunable() 
+            # kern.cam.ctl.max_luns and kern.cam.ctl.max_ports
+            max_ports, max_luns = 256, 1024
             for item in tunable:
                 if (item.get('enabled') and
                         item.get('var') == 'kern.cam.ctl.max_luns' and
                         str(item.get('value')).isnumeric()):
-                    lunallowed = min(lunallowed, int(item['value']))
+                    max_luns = int(item['value'])
                 if (item.get('enabled') and
                         item.get('var') == 'kern.cam.ctl.max_ports' and
                         str(item.get('value')).isnumeric()):
-                    lunallowed = min(lunallowed, int(item['value']))
-            LOG.debug("Tunable OS max_luns/max_ports: %s" % lunallowed)
+                    max_ports = int(item['value'])
+            attach_max_allow = min(max_luns, max_ports)
+            LOG.debug("Tunable OS max_luns/max_ports: %s", attach_max_allow)
 
         # check cinder driver already loaded before executing upstream code
         if (len(cinderapi.CONF.list_all_sections()) > 0):
@@ -172,7 +177,7 @@ class FreeNASISCSIDriver(driver.ISCSIDriver):
             vols = cinderapi.volume_get_all(ctx)
             attached_truenas_vol_count = len([vol for vol in vols
                                               if vol.host.find("@ixsystems-iscsi#") > 0 and vol.attach_status == 'attached'])
-            if (attached_truenas_vol_count >= lunallowed):
+            if (attached_truenas_vol_count >= attach_max_allow):
                 LOG.error("Maximum lun/port limitation reached. Change kern.cam.ctl.max_luns and "
                           + "kern.cam.ctl.max_ports in tunable settings to allow more lun attachments.")
                 return False

--- a/driver/ixsystems/iscsi.py
+++ b/driver/ixsystems/iscsi.py
@@ -149,7 +149,7 @@ class FreeNASISCSIDriver(driver.ISCSIDriver):
     def check_connection(self):
         # connection safety check for #27
         if ix_utils.parse_truenas_version(self.common._system_version())[1] in ('12.0', '13.0'):
-            LOG.debug("Tanable: %s", str(self.common._tunable()))
+            LOG.debug("Tunable: %s", str(self.common._tunable()))
             tunable = self.common._tunable()
             # Default value from Truenas 12 kern.cam.ctl.max_ports 256, kern.cam.ctl.max_luns 1024
             # common._tunable() returns a list of dict [{'var':'kern.cam.ctl.max_luns','enabled':True,'value':'256'}

--- a/driver/ixsystems/iscsi.py
+++ b/driver/ixsystems/iscsi.py
@@ -26,7 +26,12 @@ from cinder.volume.drivers.ixsystems.options import ixsystems_basicauth_opts
 from cinder.volume.drivers.ixsystems.options import ixsystems_connection_opts
 from cinder.volume.drivers.ixsystems.options import ixsystems_provisioning_opts
 from cinder.volume.drivers.ixsystems.options import ixsystems_transport_opts
+from cinder.volume.drivers.ixsystems.freenasapi import FreeNASApiError
 from cinder.volume.drivers.ixsystems import utils as ix_utils
+from cinder import context
+import cinder.db.api as cinderapi
+from cinder.message import api
+from cinder.message.message_field import Action, Detail
 from oslo_config import cfg
 from oslo_log import log as logging
 
@@ -141,7 +146,47 @@ class FreeNASISCSIDriver(driver.ISCSIDriver):
         """
         pass
 
+    def check_connection(self):
+        LOG.debug("Tanable: %s" % str(self.common._tunable()))
+        tunable = self.common._tunable()
+        # default value from Truenas 12 kern.cam.ctl.max_ports 256, kern.cam.ctl.max_luns 1024
+        lunallowed = 256
+        for item in tunable:
+            if (item.get('enabled') and
+                    item.get('var') == 'kern.cam.ctl.max_luns' and
+                    str(item.get('value')).isnumeric()):
+                lunallowed = min(lunallowed, int(item['value']))
+            if (item.get('enabled') and
+                    item.get('var') == 'kern.cam.ctl.max_ports' and
+                    str(item.get('value')).isnumeric()):
+                lunallowed = min(lunallowed, int(item['value']))
+        LOG.debug("Tunable OS max_luns/max_ports: %s" % lunallowed)
+
+        # check cinder driver already loaded before executing upstream code
+        if (len(cinderapi.CONF.list_all_sections()) > 0):
+            ctx = context.get_admin_context()
+            ctx.__setattr__("read_deleted", "no")
+            ctx.__setattr__("project_only", "True")
+            vols = cinderapi.volume_get_all(ctx)
+            attached_truenas_vol_count = len([vol for vol in vols
+                                              if vol.host.find("@ixsystems-iscsi#") > 0 and vol.attach_status == 'attached'])
+            if (attached_truenas_vol_count >= lunallowed):
+                LOG.error("Maximum lun/port limitation reached. Change kern.cam.ctl.max_luns and "
+                          + "kern.cam.ctl.max_ports in tunable settings to allow more lun attachments.")
+                return False
+        return True
+
     def initialize_connection(self, volume, connector):
+        """Do connection validation for know faiture before return connection to upstream cinder manager"""
+        if self.check_connection() is False:
+            exception = FreeNASApiError('Maximum lun/port limitation reached. Change kern.cam.ctl.max_luns and '
+                                        + 'kern.cam.ctl.max_ports in tunable settings to allow more lun attachments.')
+            message_api = api.API()
+            ctx = context.get_admin_context()
+            ctx.project_id = volume.project_id
+            message_api.create(ctx, action=Action.ATTACH_VOLUME, resource_uuid=volume.id,
+                               exception=exception, detail=Detail.ATTACH_ERROR)
+            raise exception
         """Driver entry point to attach a volume to an instance."""
         LOG.info('iXsystems Initialise Connection')
         freenas_volume = ix_utils.generate_freenas_volume_name(

--- a/driver/ixsystems/iscsi.py
+++ b/driver/ixsystems/iscsi.py
@@ -147,8 +147,8 @@ class FreeNASISCSIDriver(driver.ISCSIDriver):
         pass
 
     def check_connection(self):
-        # connection safety check for #27 
-        if ix_utils.parse_truenas_version(self.common._version())[1] in ('12.0', '13.0'):
+        # connection safety check for #27
+        if ix_utils.parse_truenas_version(self.common._system_version())[1] in ('12.0', '13.0'):
             LOG.debug("Tanable: %s" % str(self.common._tunable()))
             tunable = self.common._tunable()
             # default value from Truenas 12 kern.cam.ctl.max_ports 256, kern.cam.ctl.max_luns 1024
@@ -164,23 +164,22 @@ class FreeNASISCSIDriver(driver.ISCSIDriver):
                     lunallowed = min(lunallowed, int(item['value']))
             LOG.debug("Tunable OS max_luns/max_ports: %s" % lunallowed)
 
-            # check cinder driver already loaded before executing upstream code
-            if (len(cinderapi.CONF.list_all_sections()) > 0):
-                ctx = context.get_admin_context()
-                ctx.__setattr__("read_deleted", "no")
-                ctx.__setattr__("project_only", "True")
-                vols = cinderapi.volume_get_all(ctx)
-                attached_truenas_vol_count = len([vol for vol in vols
-                                                if vol.host.find("@ixsystems-iscsi#") > 0 and vol.attach_status == 'attached'])
-                if (attached_truenas_vol_count >= lunallowed):
-                    LOG.error("Maximum lun/port limitation reached. Change kern.cam.ctl.max_luns and "
-                            + "kern.cam.ctl.max_ports in tunable settings to allow more lun attachments.")
-                    return False
+        # check cinder driver already loaded before executing upstream code
+        if (len(cinderapi.CONF.list_all_sections()) > 0):
+            ctx = context.get_admin_context()
+            ctx.__setattr__("read_deleted", "no")
+            ctx.__setattr__("project_only", "True")
+            vols = cinderapi.volume_get_all(ctx)
+            attached_truenas_vol_count = len([vol for vol in vols
+                                              if vol.host.find("@ixsystems-iscsi#") > 0 and vol.attach_status == 'attached'])
+            if (attached_truenas_vol_count >= lunallowed):
+                LOG.error("Maximum lun/port limitation reached. Change kern.cam.ctl.max_luns and "
+                          + "kern.cam.ctl.max_ports in tunable settings to allow more lun attachments.")
+                return False
         return True
 
     def initialize_connection(self, volume, connector):
         """Do connection validation for know faiture before return connection to upstream cinder manager"""
-        
         if self.check_connection() is False:
             exception = FreeNASApiError('Maximum lun/port limitation reached. Change kern.cam.ctl.max_luns and '
                                         + 'kern.cam.ctl.max_ports in tunable settings to allow more lun attachments.')

--- a/driver/ixsystems/utils.py
+++ b/driver/ixsystems/utils.py
@@ -49,13 +49,14 @@ def get_iscsi_portal(hostname, port):
 
 def parse_truenas_version(version):
     """Parse and return TrueNAS verion from api to Tuple in ('FreeNAS'/'TrueNAS",'12.0'/'13.0'/'22.0','U2'/'U3') format"""
-    if len(version.split('-')) == 3:
-        main = version.split('-')[0]
-        mainversion = version.split('-')[1]
-        patch = version.split('-')[2]
+    vsplit = version.split('-')
+    if len(vsplit) == 3:
+        main = vsplit[0]
+        mainversion = vsplit[1]
+        patch = vsplit[2]
         return (main, mainversion, patch)
-    if len(version.split('-')) == 2:
-        main = version.split('-')[0]
-        mainversion = version.split('-')[1]
+    if len(vsplit) == 2:
+        main = vsplit[0]
+        mainversion = vsplit[1]
         return (main, mainversion, '')
     return ('VersionNotFound', '0', '')

--- a/driver/ixsystems/utils.py
+++ b/driver/ixsystems/utils.py
@@ -45,3 +45,16 @@ def generate_freenas_snapshot_name(name, iqn_prefix):
 def get_iscsi_portal(hostname, port):
     """Get iscsi portal info from iXsystems FREENAS configuration."""
     return "%s:%s" % (hostname, port)
+
+def parse_truenas_version(version):
+    """Parse and return TrueNAS verion from api to Tuple in ('FreeNAS'/'TrueNAS",'12.0'/'13.0'/'22.0','U2'/'U3') format"""
+    if len(version.split('-')) == 3:
+        main = version.split('-')[0]
+        mainversion = version.split('-')[1]
+        patch = version.split('-')[2]
+        return (main, mainversion, patch)
+    if len(version.split('-')) == 2:
+        main = version.split('-')[0]
+        mainversion = version.split('-')[1]
+        return (main, mainversion, '')
+    return ('VersionNotFound','0','')

--- a/driver/ixsystems/utils.py
+++ b/driver/ixsystems/utils.py
@@ -46,6 +46,7 @@ def get_iscsi_portal(hostname, port):
     """Get iscsi portal info from iXsystems FREENAS configuration."""
     return "%s:%s" % (hostname, port)
 
+
 def parse_truenas_version(version):
     """Parse and return TrueNAS verion from api to Tuple in ('FreeNAS'/'TrueNAS",'12.0'/'13.0'/'22.0','U2'/'U3') format"""
     if len(version.split('-')) == 3:
@@ -57,4 +58,4 @@ def parse_truenas_version(version):
         main = version.split('-')[0]
         mainversion = version.split('-')[1]
         return (main, mainversion, '')
-    return ('VersionNotFound','0','')
+    return ('VersionNotFound', '0', '')


### PR DESCRIPTION
#27 Add safety check function during iSCSI attach process, check TrueNAS tunable kern.cam.ctl.max_ports/kern.cam.ctl.max_luns before connection details return to upstream cinder manager. And send out proper openstack error message, TrueNAS cinder log error, volume attachment action fail and return immediately . This fix current upstream default timeout (around 2 minutes) without any proper error message return to user and cinder driver log cause user confusion.
#23 pep8 compliance fix. Minor adjustment to display proper message "TrueNAS not found" instead of "FreeNAS not supported" incase TrueNAS server is down. Remove unnecessary debug log.

Both changes manually tested on cinderlib integration check and devstack (openstack latest release), ubuntu openstack xena release, Truenas 12. Truenas 22 scale. 
Same code pass flake8 pep8 check and cinderlib integration test with TrueNAS core 12, TrueNAS scale 22 in github action here:
[github cinderlib action](https://github.com/databunnysg/iXsystemscinder/actions/runs/3794850082/jobs/6453360499)
