### PR TITLE
#13 #16 add apikey and https auth support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,11 @@ Configure the Cinder driver. Open **/etc/cinder/cinder.conf** in an editor to bo
  iscsi_helper = <iscsi helper type. Standard Value>
  volume_dd_blocksize = <block size>
  volume_driver = <Path of the main class of iXsystems cinder driver. The standard value for this driver is cinder.volume.drivers.ixsystems.iscsi.FreeNASISCSIDriver>
- ixsystems_login = <username of TrueNAS Host - currently needs to be root>
- ixsystems_password = <Password of TrueNAS Host - the root password>
+ ixsystems_apikey = <apikey of TrueNAS - optional if you choose to use username and password authentication>
+ ixsystems_login = <username of TrueNAS Host - currently needs to be root, optional if you choose to use apikey authentication>
+ ixsystems_password = <Password of TrueNAS Host - the root password, optional if you choose to use apikey authentication>
  ixsystems_server_hostname = <IP Address of TrueNAS Host>
+ ixsystems_transport_type = <TrueNAS Host API transportation protocal, http or https, default http>
  ixsystems_volume_backend_name = <driver specific information. Standard value is 'iXsystems_TRUENAS_Storage' >
  ixsystems_iqn_prefix = <Base name of ISCSI Target. (Get it from the web UI of the connected TrueNAS system by navigating: Sharing -> Block(iscsi) -> Target Global Configuration -> Base Name)>
  ixsystems_datastore_pool = <Base pool name on the connected TrueNAS host e.g. 'tank'>
@@ -66,6 +68,7 @@ Here is an example configuration:
  ixsystems_login = root
  ixsystems_password = thisisdummypassword
  ixsystems_server_hostname = 100.1.2.34
+ ixsystems_transport_type = https
  ixsystems_volume_backend_name = iXsystems_TRUENAS_Storage
  ixsystems_iqn_prefix = iqn.2005-10.org.freenas.ctl
  ixsystems_datastore_pool = tank

--- a/driver/ixsystems/common.py
+++ b/driver/ixsystems/common.py
@@ -34,18 +34,18 @@ class TrueNASCommon(object):
     VERSION = "2.0.0"
     IGROUP_PREFIX = 'openstack-'
 
-    required_flags = ['ixsystems_transport_type', 'ixsystems_login',
-                      'ixsystems_password', 'ixsystems_server_hostname',
+    required_flags = ['ixsystems_transport_type', 'ixsystems_server_hostname',
                       'ixsystems_server_port', 'ixsystems_server_iscsi_port',
                       'ixsystems_volume_backend_name', 'ixsystems_vendor_name',
                       'ixsystems_storage_protocol', 'ixsystems_datastore_pool',
-                      'ixsystems_dataset_path', 'ixsystems_iqn_prefix', ]
+                      'ixsystems_dataset_path', 'ixsystems_iqn_prefix',]
 
     def __init__(self, configuration=None):
         self.configuration = configuration
         self.backend_name = self.configuration.ixsystems_volume_backend_name
         self.vendor_name = self.configuration.ixsystems_vendor_name
         self.storage_protocol = self.configuration.ixsystems_storage_protocol
+        self.apikey = self.configuration.ixsystems_apikey
         self.stats = {}
 
     def _create_handle(self, **kwargs):
@@ -58,9 +58,9 @@ class TrueNASCommon(object):
             port=kwargs['port'],
             username=kwargs['login'],
             password=kwargs['password'],
+            apikey=kwargs['apikey'],
             api_version=kwargs['api_version'],
-            transport_type=kwargs['transport_type'],
-            style=FreeNASServer.STYLE_LOGIN_PASSWORD)
+            transport_type=kwargs['transport_type'])
         if not self.handle:
             raise FreeNASApiError("Failed to create handle for FREENAS server")
 
@@ -77,6 +77,7 @@ class TrueNASCommon(object):
             port=self.configuration.ixsystems_server_port,
             login=self.configuration.ixsystems_login,
             password=self.configuration.ixsystems_password,
+            apikey=self.configuration.ixsystems_apikey,
             api_version=self.configuration.ixsystems_api_version,
             transport_type=self.configuration.ixsystems_transport_type)
 

--- a/driver/ixsystems/iscsi.py
+++ b/driver/ixsystems/iscsi.py
@@ -23,6 +23,7 @@ import simplejson as json
 from cinder.volume import driver
 from cinder.volume.drivers.ixsystems import common
 from cinder.volume.drivers.ixsystems.options import ixsystems_basicauth_opts
+from cinder.volume.drivers.ixsystems.options import ixsystems_apikeyauth_opts
 from cinder.volume.drivers.ixsystems.options import ixsystems_connection_opts
 from cinder.volume.drivers.ixsystems.options import ixsystems_provisioning_opts
 from cinder.volume.drivers.ixsystems.options import ixsystems_transport_opts
@@ -41,6 +42,7 @@ CONF = cfg.CONF
 CONF.register_opts(ixsystems_connection_opts)
 CONF.register_opts(ixsystems_transport_opts)
 CONF.register_opts(ixsystems_basicauth_opts)
+CONF.register_opts(ixsystems_apikeyauth_opts)
 CONF.register_opts(ixsystems_provisioning_opts)
 
 
@@ -50,12 +52,11 @@ class FreeNASISCSIDriver(driver.ISCSIDriver):
     VERSION = "2.0.0"
     IGROUP_PREFIX = 'openstack-'
 
-    required_flags = ['ixsystems_transport_type', 'ixsystems_login',
-                      'ixsystems_password', 'ixsystems_server_hostname',
+    required_flags = ['ixsystems_transport_type', 'ixsystems_server_hostname',
                       'ixsystems_server_port', 'ixsystems_server_iscsi_port',
                       'ixsystems_volume_backend_name', 'ixsystems_vendor_name',
                       'ixsystems_storage_protocol', 'ixsystems_datastore_pool',
-                      'ixsystems_dataset_path', 'ixsystems_iqn_prefix', ]
+                      'ixsystems_dataset_path', 'ixsystems_iqn_prefix',]
 
     def __init__(self, *args, **kwargs):
         """Initialize FreeNASISCSIDriver Class."""
@@ -64,6 +65,7 @@ class FreeNASISCSIDriver(driver.ISCSIDriver):
         super(FreeNASISCSIDriver, self).__init__(*args, **kwargs)
         self.configuration.append_config_values(ixsystems_connection_opts)
         self.configuration.append_config_values(ixsystems_basicauth_opts)
+        self.configuration.append_config_values(ixsystems_apikeyauth_opts)
         self.configuration.append_config_values(ixsystems_transport_opts)
         self.configuration.append_config_values(ixsystems_provisioning_opts)
         self.configuration.ixsystems_iqn_prefix += ':'
@@ -154,7 +156,7 @@ class FreeNASISCSIDriver(driver.ISCSIDriver):
             # Default value from Truenas 12 kern.cam.ctl.max_ports 256, kern.cam.ctl.max_luns 1024
             # common._tunable() returns a list of dict [{'var':'kern.cam.ctl.max_luns','enabled':True,'value':'256'}
             # ,{'var':'kern.cam.ctl.max_ports','enabled':True,'value':'1024'}]
-            # Retrive attach_max_allow from min value of common._tunable() 
+            # Retrive attach_max_allow from min value of common._tunable()
             # kern.cam.ctl.max_luns and kern.cam.ctl.max_ports
             max_ports, max_luns = 256, 1024
             for item in tunable:

--- a/driver/ixsystems/options.py
+++ b/driver/ixsystems/options.py
@@ -55,6 +55,12 @@ ixsystems_basicauth_opts = [
                help='Password for the storage controller',
                secret=True), ]
 
+ixsystems_apikeyauth_opts = [
+    cfg.StrOpt('ixsystems_apikey',
+               default='',
+               help='API Key use for API key based authentication',
+               secret=True)]
+
 ixsystems_provisioning_opts = [
     cfg.StrOpt('ixsystems_datastore_pool',
                default=None,


### PR DESCRIPTION
#13 root credentials must be used enhancement
#16  driver wants to use http, not https and cannot handle 307s 

Fix and enhancements:
1. Adding both apikey authentication support and add https support for both basic user/password and apikey authentication.
2. Add ixsystems_apikey and ixsystems_transport_type to README.md for documentation purpose.
3. Remove unused code set_style, not used anywhere even in previous version.

Tested with TrueNAS 12/22 with Openstack devstack Zed release and auto test script with cinderlib.

I put some further detailed information in the code review comments FYI.

