### PR TITLE
Fix for #24 #32

### DIFF
--- a/driver/ixsystems/common.py
+++ b/driver/ixsystems/common.py
@@ -385,11 +385,9 @@ class TrueNASCommon(object):
             ret = self.handle.invoke_command(FreeNASServer.DELETE_COMMAND,
                                              request_urn, None)
             LOG.debug('_delete_snapshot response : %s', json.dumps(ret))
-
             # When deleting volume with dependent snapsnot clone, 422 error triggered. Throw VolumeIsBus exception ensures
             # upper stream cinder manager mark volume status available instead of error-deleting.
             if ret['status'] == 'error' and ret['response'] == '422:Unprocessable Entity':
-                print("volumeisbusy exeception raised")
                 errorexception = exception.VolumeIsBusy(
                     _("Cannot delete volume when clone child volume or snapshot exists!"), volume_name=name)
                 raise errorexception

--- a/driver/ixsystems/iscsi.py
+++ b/driver/ixsystems/iscsi.py
@@ -281,10 +281,10 @@ class FreeNASISCSIDriver(driver.ISCSIDriver):
     def create_cloned_volume(self, volume, src_vref):
         """Creates a volume from source volume."""
         LOG.info('iXsystems Create Cloned Volume')
-        LOG.info('create_cloned_volume: %s', src_vref['id'])
+        LOG.info('create_cloned_volume: %s', volume['id'])
 
         temp_snapshot = {'volume_name': src_vref['name'],
-                         'name': 'name-c%s' % src_vref['id']}
+                         'name': 'name-%s' % volume['id']}
 
         self.create_snapshot(temp_snapshot)
         self.create_volume_from_snapshot(volume, temp_snapshot)


### PR DESCRIPTION
Fix for below two issues:

#24 Deleting iSCSI volumes using Openstack Driver fails if one or more Truenas initiated snapshots exist enhancement
#32 Can't create multiple volumes from the same volume

For #24, special exception VolumeIsBusy raise to upper stream cinder manager in case of dependency clone caused by create volume from volume, create volume from snapshot. In this case raise VolumeIsBusy  allows upper stream cinder driver return safely, the delete volume does not stuck into error-deleting status.
After fix, when user trying to delete a volume that has cloned volume, the action simply return, volume still stay in available status, without stuck into error-delete. I tried to pop up and display a more user friendly error message but limit to current upstream code, no luck so far. This maybe enhanced later on but might heavily depends on upstream code.

For #32, issue is caused by when create volume from volume, volume snapshot name hardcoded to parent volume name, which cause create second snapshot failed for the same parent volume. Fix change snapshot name to newly created volume id which is unique for each creation. Note: this should not be confused with openstack create snapshot from volume, openstack create snapshot from volume is separate action from create volume from volume.