### PR TITLE
Add unit test case for ix cinder driver per upstream code submission requirement

### DIFF
--- a/test/test_common.py
+++ b/test/test_common.py
@@ -1,0 +1,177 @@
+import unittest
+from unittest.mock import Mock,patch, MagicMock
+import ddt
+from cinder.volume.drivers.ixsystems.common import TrueNASCommon
+from cinder.volume import configuration as conf
+
+@ddt.ddt
+class CommonTestCase(unittest.TestCase):
+
+    def setUp(self):
+        CONF = Mock(spec=conf.Configuration)
+        CONF.iscsi_helper = 'tgtadm'
+        CONF.volume_dd_blocksize = 512
+        CONF.volume_driver = 'cinder.volume.drivers.ixsystems.iscsi.FreeNASISCSIDriver'
+        CONF.ixsystems_login = 'root'
+        CONF.ixsystems_password = 'Pa55w0rd'
+        CONF.ixsystems_apikey = ''
+        CONF.ixsystems_server_hostname = '10.3.1.81'
+        CONF.ixsystems_server_port = 80
+        CONF.ixsystems_transport_type = 'http'
+        CONF.ixsystems_volume_backend_name = 'iXsystems_FREENAS_Storage'
+        CONF.ixsystems_iqn_prefix = 'iqn.2005-10.org.freenas.ctl'
+        CONF.ixsystems_datastore_pool = 'cinder-zpool'
+        CONF.ixsystems_dataset_path = 'cinder-zpool/mydataset'
+        CONF.ixsystems_vendor_name = 'iXsystems'
+        CONF.ixsystems_storage_protocol = 'iscsi'
+        CONF.ixsystems_server_iscsi_port = 3260
+        CONF.ixsystems_api_version = 'v2.0'
+
+        self.common = TrueNASCommon(configuration=CONF)
+        self.common.do_custom_setup()
+
+    def test_check_flags(self):
+        self.assertIsNone(self.common.check_flags())
+        
+    def test_do_custom_setup(self):
+        self.assertIsNone(self.common.do_custom_setup())
+
+    @ddt.data(("vol1",1,"/pool/dataset",b'{"name": "cinder-zpool/mydataset/vol1", "type": "VOLUME", "volsize": 1073741824}'
+               ))
+    @ddt.unpack
+    def test_create_volume(self,volname,volsize, request_d,urlreadresult):
+        urlrespond = MagicMock(name="urlrespond")
+        urlrespondcontext = MagicMock(name="urlrespondcontext")
+        urlrespond.__enter__.return_value = urlrespondcontext
+        urlrespondcontext.read.return_value = urlreadresult
+        with patch('cinder.volume.drivers.ixsystems.freenasapi.urllib.request') as mock_request:
+            with patch('cinder.volume.drivers.ixsystems.freenasapi.urllib.request.urlopen',return_value =urlrespond) as mock_urlopen:
+                self.common.create_volume(volname,volsize)
+                self.assertEqual(mock_request.method_calls[0][1][0],self.common.handle.get_url()+request_d)
+                self.assertEqual(mock_request.method_calls[0][1][1],urlreadresult)
+
+    @ddt.data(("target-6410a089",
+               b'[{"id":2,"name":"target-6410a089","alias":null,"mode":"ISCSI","groups":[{"portal":1,"initiator":1,"auth":null,"authmethod":"NONE"}]}]',
+               2))
+    @ddt.unpack
+    def test_get_iscsitarget_id(self,name, urlreadresult,expected):
+        urlrespond = MagicMock(name="urlrespond")
+        urlrespondcontext = MagicMock(name="urlrespondcontext")
+        urlrespond.__enter__.return_value = urlrespondcontext
+        urlrespondcontext.read.return_value = urlreadresult
+        with patch('cinder.volume.drivers.ixsystems.freenasapi.urllib.request') as mock_request:
+            with patch('cinder.volume.drivers.ixsystems.freenasapi.urllib.request.urlopen',return_value =urlrespond) as mock_urlopen:
+                self.assertEqual(self.common.get_iscsitarget_id(name), expected)
+
+    @ddt.data(("target-6410a089",
+               b'[{"id":2,"name":"target-6410a089","serial":"000c29aef785001","type":"DISK","path":"zvol/pool/cinder/volume-6410a089","filesize":"0","blocksize":512,"pblocksize":false,"avail_threshold":null,"comment":"","naa":"0x6589cfc00000033f74d0d84613b0caea","insecure_tpc":true,"xen":false,"rpm":"SSD","ro":false,"enabled":true,"vendor":"TrueNAS","disk":"zvol/pool/cinder/volume-6410a089","locked":false}]',
+               2))
+    @ddt.unpack
+    def test_get_extent_id(self,name, urlreadresult,expected):
+        urlrespond = MagicMock(name="urlrespond")
+        urlrespondcontext = MagicMock(name="urlrespondcontext")
+        urlrespond.__enter__.return_value = urlrespondcontext
+        urlrespondcontext.read.return_value = urlreadresult
+        with patch('cinder.volume.drivers.ixsystems.freenasapi.urllib.request') as mock_request:
+            with patch('cinder.volume.drivers.ixsystems.freenasapi.urllib.request.urlopen',return_value =urlrespond) as mock_urlopen:
+                self.assertEqual(self.common.get_extent_id(name), expected)                            
+
+    @ddt.data(("target-6410a089",
+               b'[{"id":0,"lunid":0,"extent":2,"target":2}]',
+               0))
+    @ddt.unpack
+    def test_get_tgt_ext_id(self,name, urlreadresult,expected):
+        urlrespond = MagicMock(name="urlrespond")
+        urlrespondcontext = MagicMock(name="urlrespondcontext")
+        urlrespond.__enter__.return_value = urlrespondcontext
+        urlrespondcontext.read.return_value = urlreadresult
+        with patch('cinder.volume.drivers.ixsystems.freenasapi.urllib.request') as mock_request:
+            with patch('cinder.volume.drivers.ixsystems.freenasapi.urllib.request.urlopen',return_value =urlrespond) as mock_urlopen:
+                self.assertEqual(self.common.get_tgt_ext_id(name), expected)                
+
+    @ddt.data(("target-6410a089", "target-6410a089",))
+    @ddt.unpack
+    def test_create_iscsitarget(self,name, volume_name):
+        self.common._create_target = MagicMock()
+        self.common._create_extent = MagicMock()
+        self.common._target_to_extent = MagicMock()
+        self.assertIsNone(self.common.create_iscsitarget(name, volume_name))
+        self.common._create_target.assert_called_once()
+        self.common._create_extent.assert_called_once()
+        self.common._target_to_extent.assert_called_once()
+
+    @ddt.data(("12",
+               "/iscsi/target/id/12",
+              b'true'))
+    @ddt.unpack
+    def test_delete_target(self,targetid, request_d, urlreadresult):
+        urlrespond = MagicMock(name="urlrespond")
+        urlrespondcontext = MagicMock(name="urlrespondcontext")
+        urlrespond.__enter__.return_value = urlrespondcontext
+        urlrespondcontext.read.return_value = urlreadresult
+        with patch('cinder.volume.drivers.ixsystems.freenasapi.urllib.request') as mock_request:
+            with patch('cinder.volume.drivers.ixsystems.freenasapi.urllib.request.urlopen',return_value =urlrespond) as mock_urlopen:
+                self.common.delete_target(targetid)
+                self.assertEqual(mock_request.method_calls[0][1][0],self.common.handle.get_url()+request_d)
+
+    @ddt.data(("12",
+               "/iscsi/extent/id/12",
+              b'true'))
+    @ddt.unpack
+    def test_delete_extent(self,targetid, request_d, urlreadresult):
+        urlrespond = MagicMock(name="urlrespond")
+        urlrespondcontext = MagicMock(name="urlrespondcontext")
+        urlrespond.__enter__.return_value = urlrespondcontext
+        urlrespondcontext.read.return_value = urlreadresult
+        with patch('cinder.volume.drivers.ixsystems.freenasapi.urllib.request') as mock_request:
+            with patch('cinder.volume.drivers.ixsystems.freenasapi.urllib.request.urlopen',return_value =urlrespond) as mock_urlopen:
+                self.common.delete_extent(targetid)
+                self.assertEqual(mock_request.method_calls[0][1][0],self.common.handle.get_url()+request_d)
+
+    @ddt.data(("volume-9e9ab808",
+               "/pool/dataset/id/cinder-zpool%2Fmydataset%2Fvolume-9e9ab808",
+              b'true'))
+    @ddt.unpack
+    def test_delete_volume(self,name, request_d, urlreadresult):
+        urlrespond = MagicMock(name="urlrespond")
+        urlrespondcontext = MagicMock(name="urlrespondcontext")
+        urlrespond.__enter__.return_value = urlrespondcontext
+        urlrespondcontext.read.return_value = urlreadresult
+        with patch('cinder.volume.drivers.ixsystems.freenasapi.urllib.request') as mock_request:
+            with patch('cinder.volume.drivers.ixsystems.freenasapi.urllib.request.urlopen',return_value =urlrespond) as mock_urlopen:
+                self.common._dependent_clone = MagicMock(return_value=False)
+                self.common.delete_volume(name)
+                self.assertEqual(mock_request.method_calls[0][1][0],self.common.handle.get_url()+request_d)                                
+
+    @ddt.data(("snap-8b839f49",
+               "volume-cf879408",
+               "/zfs/snapshot",
+              b'{"id":"pool/cinder/volume-cf879408@snap-8b839f49","name":"pool/cinder/volume-cf879408@snap-8b839f49","pool":"pool","type":"SNAPSHOT"}'))
+    @ddt.unpack
+    def test_create_snapshot(self,name,volume_name, request_d, urlreadresult):
+        urlrespond = MagicMock(name="urlrespond")
+        urlrespondcontext = MagicMock(name="urlrespondcontext")
+        urlrespond.__enter__.return_value = urlrespondcontext
+        urlrespondcontext.read.return_value = urlreadresult
+        with patch('cinder.volume.drivers.ixsystems.freenasapi.urllib.request') as mock_request:
+            with patch('cinder.volume.drivers.ixsystems.freenasapi.urllib.request.urlopen',return_value =urlrespond) as mock_urlopen:
+                self.common.create_snapshot(name,volume_name)
+                self.assertEqual(mock_request.method_calls[0][1][0],self.common.handle.get_url()+request_d)
+
+    @ddt.data(("snap-8b839f49",
+               "volume-cf879408",
+               "/zfs/snapshot/id/cinder-zpool%2Fmydataset%2Fvolume-cf879408@snap-8b839f49",
+              b'{"id":"pool/cinder/volume-cf879408@snap-8b839f49","name":"pool/cinder/volume-cf879408@snap-8b839f49","pool":"pool","type":"SNAPSHOT"}'))
+    @ddt.unpack
+    def test_delete_snapshot(self,name,volume_name, request_d, urlreadresult):
+        urlrespond = MagicMock(name="urlrespond")
+        urlrespondcontext = MagicMock(name="urlrespondcontext")
+        urlrespond.__enter__.return_value = urlrespondcontext
+        urlrespondcontext.read.return_value = urlreadresult
+        with patch('cinder.volume.drivers.ixsystems.freenasapi.urllib.request') as mock_request:
+            with patch('cinder.volume.drivers.ixsystems.freenasapi.urllib.request.urlopen',return_value =urlrespond) as mock_urlopen:
+                self.common.delete_snapshot(name,volume_name)
+                self.assertEqual(mock_request.method_calls[0][1][0],self.common.handle.get_url()+request_d)
+                     
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_freenasapi.py
+++ b/test/test_freenasapi.py
@@ -1,0 +1,89 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import ddt
+from cinder.volume.drivers.ixsystems.freenasapi import FreeNASServer
+
+@ddt.ddt
+class FreeNasServerTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.freeNasServer = FreeNASServer("host","80","root","password","","v2.0","http")
+          
+    @ddt.data(("select","GET"),
+              ("create","POST"),
+              ("update","PUT"),
+              ("delete","DELETE"),
+              ("",None))
+    @ddt.unpack
+    def test_get_method(self, command_d, expected):
+        self.assertEqual(expected,self.freeNasServer._get_method(command_d))
+
+    @ddt.data(("host"))
+    def test_get_host(self, expected):
+        self.assertEqual(expected,self.freeNasServer.get_host())
+
+    @ddt.data(("80"))
+    def test_get_port(self, expected):
+        self.assertEqual(expected,self.freeNasServer.get_port())
+
+    @ddt.data(("root"))
+    def test_get_username(self, expected):
+        self.assertEqual(expected,self.freeNasServer.get_username())
+
+    @ddt.data(("password"))
+    def test_get_password(self, expected):
+        self.assertEqual(expected,self.freeNasServer.get_password())
+
+    @ddt.data(("http"))
+    def test_get_transport_type(self, expected):
+        self.assertEqual(expected,self.freeNasServer.get_transport_type())
+
+    @ddt.data(("http://host/api/v2.0"))
+    def test_get_url(self, expected):
+        self.assertEqual(expected,self.freeNasServer.get_url())
+        
+    @ddt.data(("host","host"))
+    @ddt.unpack
+    def test_set_host(self, input, expected):
+        self.freeNasServer.set_host(input)
+        self.assertEqual(expected,self.freeNasServer.get_host())
+
+    @ddt.data(("80","80"))
+    @ddt.unpack
+    def test_set_port(self, input, expected):
+        self.freeNasServer.set_port(input)
+        self.assertEqual(expected,self.freeNasServer.get_port())
+
+    @ddt.data(("root","root"))
+    @ddt.unpack
+    def test_set_username(self, input, expected):
+        self.freeNasServer.set_username(input)
+        self.assertEqual(expected,self.freeNasServer.get_username())
+
+    @ddt.data(("password","password"))
+    @ddt.unpack    
+    def test_set_password(self, input, expected):
+        self.freeNasServer.set_password(input)
+        self.assertEqual(expected,self.freeNasServer.get_password())
+
+    @ddt.data(("http","http"))
+    @ddt.unpack    
+    def test_set_transport_type(self, input, expected):
+        self.freeNasServer.set_transport_type(input)
+        self.assertEqual(expected,self.freeNasServer.get_transport_type())
+                                                
+    @ddt.data(("select","/system/version",None,'"TrueNAS-12.0-U8.1"',{"status": "ok", "response": "\"TrueNAS-12.0-U8.1\"", "code": -1})
+              ,("select","/pool/dataset/id/pool%2Fcinder",None,'{ "id": 12, "name": "target-8cf1022d", "serial": "000c29aef785011", "type": "DISK", "path": "zvol/pool/cinder/volume-8cf1022d", "filesize": "0", "blocksize": 512, "pblocksize": false, "avail_threshold": null, "comment": "", "naa": "0x6589cfc0000004c025f61cbddb466907", "insecure_tpc": true, "xen": false, "rpm": "SSD", "ro": false, "enabled": true, "vendor": "TrueNAS", "disk": "zvol/pool/cinder/volume-8cf1022d", "locked": false}',
+                {"status": "ok", "response": "{ \"id\": 12, \"name\": \"target-8cf1022d\", \"serial\": \"000c29aef785011\", \"type\": \"DISK\", \"path\": \"zvol/pool/cinder/volume-8cf1022d\", \"filesize\": \"0\", \"blocksize\": 512, \"pblocksize\": false, \"avail_threshold\": null, \"comment\": \"\", \"naa\": \"0x6589cfc0000004c025f61cbddb466907\", \"insecure_tpc\": true, \"xen\": false, \"rpm\": \"SSD\", \"ro\": false, \"enabled\": true, \"vendor\": \"TrueNAS\", \"disk\": \"zvol/pool/cinder/volume-8cf1022d\", \"locked\": false}", "code": -1} ))
+    @ddt.unpack
+    def test_invoke_command(self,command_d, request_d, param_list,urlread,expected):
+        urlrespond = MagicMock(name="urlrespond")
+        urlrespondcontext = MagicMock(name="urlrespondcontext")
+        urlrespond.__enter__.return_value = urlrespondcontext
+        urlrespondcontext.read.return_value = urlread
+        with patch('cinder.volume.drivers.ixsystems.freenasapi.urllib.request') as mock_request:
+            with patch('cinder.volume.drivers.ixsystems.freenasapi.urllib.request.urlopen',return_value =urlrespond) as mock_urlopen:
+                self.assertEqual(expected,self.freeNasServer.invoke_command(command_d, request_d, param_list))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,0 +1,40 @@
+import unittest
+import ddt
+
+from cinder.volume.drivers.ixsystems import utils as ix_utils
+
+@ddt.ddt
+class UtilsTestCase(unittest.TestCase):
+    
+    @ddt.data((1024 * 1024 * 1024,1),(1.5*1024 * 1024 * 1024,1.5))
+    @ddt.unpack
+    def test_get_size_in_gb(self,size_in_bytes,expected):
+        self.assertEqual(expected, ix_utils.get_size_in_gb(size_in_bytes))
+
+    @ddt.data(("123456-123456-abcdef-abcdef-abcdef","iqn","volume-123456"),
+              ("234567-234567-abcdef-abcdef-abcdef","iqn","volume-234567"))
+    @ddt.unpack
+    def test_generate_freenas_volume_name(self,name,iqn_prefix,expected):
+        self.assertEqual(expected, ix_utils.generate_freenas_volume_name(name,iqn_prefix)['name'])
+
+    @ddt.data(("123456-123456-abcdef-abcdef-abcdef","iqn","snap-123456"),
+              ("234567-234567-abcdef-abcdef-abcdef","iqn","snap-234567"))
+    @ddt.unpack
+    def test_generate_freenas_snapshot_name(self,name, iqn_prefix,expected):
+        self.assertEqual(expected, ix_utils.generate_freenas_snapshot_name(name,iqn_prefix)['name'])
+
+    @ddt.data(("server1","3260","server1:3260"),
+              ("server2","3261","server2:3261"))
+    @ddt.unpack    
+    def test_get_iscsi_portal(self,hostname, port,expected):
+        self.assertEqual(expected, ix_utils.get_iscsi_portal(hostname,port))
+
+
+    @ddt.data(("TrueNAS-12.0-U8.1",("TrueNAS","12.0","U8.1")),
+              ("",('VersionNotFound', '0', '')))
+    @ddt.unpack    
+    def test_parse_truenas_version(self,version,expected):
+        self.assertEqual(expected, ix_utils.parse_truenas_version(version))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Add unit test case for ix cinder driver per upstream code submission requirements:

Unit test added:
test/test_common.py
test/test_freenasapi.py
test/test_utils.py

Note: 
1. Test lib use python unittest library mock/patch in favor of other existing cinder driver test case.
2. Mainly patch two urllib objects to simulate Truenas api call:
cinder.volume.drivers.ixsystems.freenasapi.urllib.request
cinder.volume.drivers.ixsystems.freenasapi.urllib.request.urlopen
3. All test pass with latest ix master branch driver code.
