### PR TITLE
Enhancement fix for #41 Cinder volume/snapshot cascade delete not successful

### DIFF
--- a/driver/ixsystems/common.py
+++ b/driver/ixsystems/common.py
@@ -618,7 +618,7 @@ class TrueNASCommon(object):
                   "schedule": {"minute": "*", "hour":"*", "dom":"*", "month":"*", "dow":"*",
                                "begin":"00:00","end":"23:59"}, 
                   "also_include_naming_schema": [naming_schema],"only_matching_schedule":True
-                  ,"retention_policy": "SOURCE"}
+                  ,"retention_policy": "SOURCE","readonly":"IGNORE"}
         jparams = json.dumps(params)
         jparams = jparams.encode('utf8')
         LOG.debug(f'replicate_volume_from_snapshot urn : {request_urn}')

--- a/driver/ixsystems/freenasapi.py
+++ b/driver/ixsystems/freenasapi.py
@@ -51,6 +51,7 @@ class FreeNASServer(object):
     REST_API_TARGET_TO_EXTENT = "/iscsi/targetextent"
     # REST_API_TARGET_GROUP = "/services/iscsi/targetgroup/"
     REST_API_SNAPSHOT = "/zfs/snapshot"
+    REST_API_REPLICATION = "/replication"
     ZVOLS = "zvols"
     TARGET_ID = -1  # We assume invalid id to begin with
     STORAGE_TABLE = "/storage"

--- a/driver/ixsystems/iscsi.py
+++ b/driver/ixsystems/iscsi.py
@@ -304,14 +304,13 @@ class FreeNASISCSIDriver(driver.ISCSIDriver):
 
         temp_snapshot = {'volume_name': src_vref['name'],
                          'name': f'name-{volume["id"]}'}
-
+        # New implementation uses replication api to create cloned volume 
+        # from snapshot, this removes the dependency between parent volume
+        # snapshot and cloned volume. Temp snapshot need to be removed after 
+        # clone successful
         self.create_snapshot(temp_snapshot)
         self.create_volume_from_snapshot(volume, temp_snapshot)
-        # self.delete_snapshot(temp_snapshot)
-        # with API v2.0 this causes FreeNAS error
-        # "snapshot has dependent clones".  Cannot delete while volume is
-        # active.  Instead, added check and deletion of orphaned dependent
-        # clones in common._delete_volume()
+        self.delete_snapshot(temp_snapshot)
 
     def extend_volume(self, volume, new_size):
         """Driver entry point to extend an existing volumes size."""

--- a/driver/ixsystems/options.py
+++ b/driver/ixsystems/options.py
@@ -37,7 +37,7 @@ ixsystems_connection_opts = [
                help='vendor name on Storage controller'),
     cfg.StrOpt('ixsystems_storage_protocol',
                default='iscsi',
-               help='storage protocol on Storage controller'), ]
+               help='storage protocol on Storage controller'),]
 
 ixsystems_transport_opts = [
     cfg.StrOpt('ixsystems_transport_type',
@@ -77,4 +77,7 @@ ixsystems_provisioning_opts = [
                help='Storage controller iSCSI portal ID'),
     cfg.StrOpt('ixsystems_initiator_id',
                default=1,
-               help='Storage controller iSCSI Initiator ID'), ]
+               help='Storage controller iSCSI Initiator ID'),
+    cfg.StrOpt('ixsystems_replication_timetout',
+               default='600',
+               help='default 600 seconds for creating volume from snapshot by using replication API'),]

--- a/driver/ixsystems/options.py
+++ b/driver/ixsystems/options.py
@@ -78,6 +78,6 @@ ixsystems_provisioning_opts = [
     cfg.StrOpt('ixsystems_initiator_id',
                default=1,
                help='Storage controller iSCSI Initiator ID'),
-    cfg.StrOpt('ixsystems_replication_timetout',
+    cfg.StrOpt('ixsystems_replication_timeout',
                default='600',
                help='default 600 seconds for creating volume from snapshot by using replication API'),]

--- a/driver/ixsystems/utils.py
+++ b/driver/ixsystems/utils.py
@@ -34,7 +34,7 @@ def generate_freenas_volume_name(name, iqn_prefix):
 
 def generate_freenas_snapshot_name(name, iqn_prefix):
     """Create FREENAS snapshot / iscsitarget name from Cinder name."""
-    backend_snap = 'snap-' + name.split('-')[1]
+    backend_snap = 'snap-' + name.split('-')[1] + '-1111-11-11-11-11'
     backend_target = 'target-' + name.split('-')[1]
     backend_iqn = iqn_prefix + backend_target
     return {'name': backend_snap,

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -419,7 +419,7 @@ fake_config_dict = {
     'ixsystems_server_iscsi_port': 3260,
     'ixsystems_api_version': 'v2.0',
     'ixsystems_reserved_percentage': 0,
-    'ixsystems_replication_timetout' : 600
+    'ixsystems_replication_timeout' : 600
     }
 
 

--- a/test/test_iscsi.py
+++ b/test/test_iscsi.py
@@ -272,7 +272,7 @@ fake_config_dict = {
     'ixsystems_server_iscsi_port': 3260,
     'ixsystems_api_version': 'v2.0',
     'ixsystems_reserved_percentage': 0,
-    'ixsystems_replication_timetout': 600
+    'ixsystems_replication_timeout': 600
     }
 
 
@@ -309,7 +309,7 @@ class FreeNASISCSIDriverTestCase(unittest.TestCase):
         CONF.ixsystems_server_iscsi_port = 3260
         CONF.ixsystems_api_version = 'v2.0'
         CONF.ixsystems_reserved_percentage = 0
-        CONF.ixsystems_replication_timetout = 600
+        CONF.ixsystems_replication_timeout = 600
         self.driver = fakeiscsidriver(configuration=CONF)
 
     def test_check_for_setup_error(self):

--- a/test/test_iscsi.py
+++ b/test/test_iscsi.py
@@ -27,6 +27,7 @@ class fakecommon(TrueNASCommon):
         self.common._target_to_extent = MagicMock()
         self.common._dependent_clone = MagicMock()
         self.common.delete_iscsitarget = MagicMock()
+        self.common.replicate_volume_from_snapshot = MagicMock()
         super().__init__(configuration=CONF)
 
     def _create_handle(self, **kwargs):
@@ -148,17 +149,25 @@ class fakecommon(TrueNASCommon):
             with patch(open_patch, return_value=urlrespond):
                 self.common.delete_snapshot(name, volume_name)
 
-    def create_volume_from_snapshot(self, name, snapshot_name, snap_zvol_name):
-        urlreadresult = b'{"snapshot": "pool/cinder/volume-be93bccd@snap-7'\
-            b'9fe98cf", "dataset_dst": "pool/cinder/volume-83b64291"}'
+    def replicate_volume_from_snapshot(self, target_volume_name,
+                                            snapshot_name, src_volume_name):
+        urlreadresult =  b'{ "id": 1, "target_dataset": "pool/cinder/volume-'\
+            b'ba323557","state": {"state": "FINISHED"}}'
+        replicationstatresult = b'{ "id": 1, "target_dataset": "pool/cinder/'\
+            b'volume-ba323557","state": {"state": "FINISHED"}}'
         urlrespond = MagicMock(name="urlrespond")
         urlrespondcontext = MagicMock(name="urlrespondcontext")
         urlrespond.__enter__.return_value = urlrespondcontext
         urlrespondcontext.read.return_value = urlreadresult
+        self.common.replication_run = MagicMock()
+        self.common.replication_stats = MagicMock(return_value
+                                                  = replicationstatresult)
+        self.common.delete_snapshot = MagicMock()
         with patch(request_patch):
             with patch(open_patch, return_value=urlrespond):
-                self.common.create_volume_from_snapshot(name, snapshot_name,
-                                                        snap_zvol_name)
+                self.common.replicate_volume_from_snapshot(target_volume_name,
+                                                           snapshot_name,
+                                                           src_volume_name)
 
     def promote_volume(self, volume_name):
         urlreadresult = b'null'
@@ -240,7 +249,7 @@ FakeConnector = {'initiator': 'iqn.2005-10.org.freenas.ctltarget-2b12',
                  }
 
 
-FakeSnapshot = {'name': "snap-fakeid", 'volume_name': 'fake-volumeid'}
+FakeSnapshot = {'name': "snap-fakeid-1111-11-11-11-11", 'volume_name': 'fake-volumeid'}
 
 
 fake_config_dict = {
@@ -262,7 +271,8 @@ fake_config_dict = {
     'ixsystems_storage_protocol': 'iscsi',
     'ixsystems_server_iscsi_port': 3260,
     'ixsystems_api_version': 'v2.0',
-    'ixsystems_reserved_percentage': 0
+    'ixsystems_reserved_percentage': 0,
+    'ixsystems_replication_timetout': 600
     }
 
 
@@ -299,6 +309,7 @@ class FreeNASISCSIDriverTestCase(unittest.TestCase):
         CONF.ixsystems_server_iscsi_port = 3260
         CONF.ixsystems_api_version = 'v2.0'
         CONF.ixsystems_reserved_percentage = 0
+        CONF.ixsystems_replication_timetout = 600
         self.driver = fakeiscsidriver(configuration=CONF)
 
     def test_check_for_setup_error(self):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -20,8 +20,8 @@ class UtilsTestCase(unittest.TestCase):
                          ix_utils.generate_freenas_volume_name(
                              name, iqn_prefix)['name'])
 
-    @ddt.data(("123456-123456-abcdef-abcdef-abcdef", "iqn", "snap-123456"),
-              ("234567-234567-abcdef-abcdef-abcdef", "iqn", "snap-234567"))
+    @ddt.data(("123456-123456-abcdef-abcdef-abcdef", "iqn", "snap-123456-1111-11-11-11-11"),
+              ("234567-234567-abcdef-abcdef-abcdef", "iqn", "snap-234567-1111-11-11-11-11"))
     @ddt.unpack
     def test_generate_freenas_snapshot_name(self, name, iqn_prefix, expected):
         self.assertEqual(expected, ix_utils.generate_freenas_snapshot_name(


### PR DESCRIPTION
**Issue:**
when using cinder client with --cascade parameter to delete volume with snapshot attached
#cinder delete --cascade 2762015d-cad8-4b03-a117-63e10ea9406b
Request to delete volume 2762015d-cad8-4b03-a117-63e10ea9406b has been accepted.
Unexpected result: the snapshot and any volume cloned from this snapshot not deleted
Expected result: volume, snapshot and volume cloned from snapshot all deleted

This also failed tempest test case: https://docs.openstack.org/tempest/latest/_modules/volume/test_volume_delete_cascade.html

**Root cause:**
OpenStack requires a snapshot to be independent of child volume. However, the existing truenas /zfs/snapshot/clone api does not support this.
For example, VolumeA  create snapsnot volumeA@snapshot,  volumeA@snapshot create child volume volumeAsnapshotchild. At this time, volumeA@snapshot should be able to removed safely. There should be no dependency between volumeA@snapshot and volumeAsnapshotchild. However this is not possible with the current Truenas/freenas /zfs/snapshot/clone api. Promote volumeAsnapshotchild won't help, cause as long as VolumeA exists there are dependencies prevented from volumeA@snapshot to be removed.

**Solution:**
Use Truenas replication api to replicate from zfs snapshot to new Truenas zvol volume, in this way, the new volume is independent with source volume.

_File changes:_
driver/ixsystems/common.py
driver/ixsystems/freenasapi.py
driver/ixsystems/iscsi.py
driver/ixsystems/options.py
driver/ixsystems/utils.py
test/test_common.py
test/test_iscsi.py
test/test_utils.py

_New functions added:_
common.py replicate_volume_from_snapshot
common.py replication_stats
common.py replication_delete
common.py replication_run
_Function modified:_
iscsi.py create_volume_from_snapshot 
Changed from old zfs snapshot clone based implementation to replication api based implementation
utils.py generate_freenas_snapshot_name
Changed snapshot naming convention to snap-xxxxxx-1111-11-11-11-11 dual to replication api requires snapshot to have a valid schema requires the %Y (year), %m (month), %d (day), %H (hour), and %M (minute) time strings.

_Unit test cases:_
test_common.py test_replicate_volume_from_snapshot
test_common.py test_replication_delete
test_common.py test_replication_run
test_common.py test_replication_stats
test_iscsi.py replicate_volume_from_snapshot
test_utils.py test_generate_freenas_snapshot_name

