### PR TITLE
Enhancement fix for #42 adding manage/unmanage support for volume/snapshot

### DIFF
--- a/driver/ixsystems/common.py
+++ b/driver/ixsystems/common.py
@@ -733,7 +733,7 @@ class TrueNASCommon(object):
             raise FreeNASApiError('Unexpected error', api_error) from api_error
 
     def get_all_snapshot(self):
-        """ Use dataset API /v2.0/zfs/snapshot/ to get all snapshot details
+        """ Use zfs snapshot API /v2.0/zfs/snapshot/ to get all snapshot details
         """
         LOG.debug(f'get_all_snapshot')
         request_urn = (f"/zfs/snapshot/")
@@ -749,7 +749,7 @@ class TrueNASCommon(object):
 
     def get_volume_from_snapshot(self, snapshot_name):
         """
-        Use dataset API /v2.0/zfs/snapshot/ to get volume name from snapshot
+        Use zfs snapshot API /v2.0/zfs/snapshot/ to get volume name from snapshot
         """
         all_snapshot = self.get_all_snapshot()
         snaplist = [snap for snap in all_snapshot

--- a/driver/ixsystems/iscsi.py
+++ b/driver/ixsystems/iscsi.py
@@ -435,7 +435,7 @@ class FreeNASISCSIDriver(driver.ISCSIDriver):
                 exception = FreeNASApiError('It is not possible to manage a '\
                     'snapshot does not originate from a cinder managed volume')
                 raise exception
-        # Implementation of rename rename existing snapshot to new snapshot
+        # Implementation of rename existing snapshot to new openstack snapshot id
         # However truenas does not expose snapshot rename api 
         # Leave for future implementation
 

--- a/driver/ixsystems/utils.py
+++ b/driver/ixsystems/utils.py
@@ -25,17 +25,28 @@ def get_bytes_from_gb(size_in_gb):
 
 def generate_freenas_volume_name(name, iqn_prefix):
     """Create FREENAS volume / iscsitarget name from Cinder name."""
-    backend_volume = 'volume-' + name.split('-')[1]
-    backend_target = 'target-' + name.split('-')[1]
+    backend_volume = 'volume-' + name
+    backend_target = 'target-' + name
     backend_iqn = iqn_prefix + backend_target
     return {'name': backend_volume,
             'target': backend_target, 'iqn': backend_iqn}
 
+def generate_volume_id_from_freenas_volume_name(name):
+    """Create Cinder volume name from FREENAS volume name."""
+    return name.replace('volume-', '')
+
+def generate_snapshot_id_from_freenas_snapshot_name(name):
+    """Create Cinder volume name from FREENAS volume name."""
+    return name.replace('snap-', '').replace('-1111-11-11-11-11', '')
 
 def generate_freenas_snapshot_name(name, iqn_prefix):
     """Create FREENAS snapshot / iscsitarget name from Cinder name."""
-    backend_snap = 'snap-' + name.split('-')[1] + '-1111-11-11-11-11'
-    backend_target = 'target-' + name.split('-')[1]
+    backend_snap = name
+    if not backend_snap.startswith('snap-'):
+        backend_snap = f"snap-{backend_snap}"
+    if not backend_snap.endswith('-1111-11-11-11-11'):
+        backend_snap = f"{backend_snap}-1111-11-11-11-11"
+    backend_target = 'target-' + name
     backend_iqn = iqn_prefix + backend_target
     return {'name': backend_snap,
             'target': backend_target, 'iqn': backend_iqn}

--- a/driver/ixsystems/utils.py
+++ b/driver/ixsystems/utils.py
@@ -32,11 +32,11 @@ def generate_freenas_volume_name(name, iqn_prefix):
             'target': backend_target, 'iqn': backend_iqn}
 
 def generate_volume_id_from_freenas_volume_name(name):
-    """Create Cinder volume name from FREENAS volume name."""
+    """Create Cinder volume id from FREENAS volume name."""
     return name.replace('volume-', '')
 
 def generate_snapshot_id_from_freenas_snapshot_name(name):
-    """Create Cinder volume name from FREENAS volume name."""
+    """Create Cinder snapshot id from FREENAS snapshot name."""
     return name.replace('snap-', '').replace('-1111-11-11-11-11', '')
 
 def generate_freenas_snapshot_name(name, iqn_prefix):

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -391,8 +391,8 @@ class TrueNASCommonTestCase(unittest.TestCase):
                                  self.common.handle.get_url()+request_d)
 
     @ddt.data(("f9ecfc53-2b12-4bfb-abe1-694970cc1341",
-               "10.3.1.81:3260,target-2b12 iqn.2005-10.org."
-               "freenas.ctltarget-2b12"))
+               "10.3.1.81:3260,target-f9ecfc53-2b12-4bfb-abe1-694970cc1341 iqn.2005-10.org."
+               "freenas.ctltarget-f9ecfc53-2b12-4bfb-abe1-694970cc1341"))
     @ddt.unpack
     def test_create_export(self, volume_name, expected):
         handle = self.common.create_export(volume_name)

--- a/test/test_iscsi.py
+++ b/test/test_iscsi.py
@@ -249,7 +249,7 @@ FakeConnector = {'initiator': 'iqn.2005-10.org.freenas.ctltarget-2b12',
                  }
 
 
-FakeSnapshot = {'name': "snap-fakeid-1111-11-11-11-11", 'volume_name': 'fake-volumeid'}
+FakeSnapshot = {'name': "snap-fakeid-1111-11-11-11-11", 'volume_name': 'fake-volumeid', 'id': 'fakeid', 'volume_id': 'fake-volumeid'}
 
 
 fake_config_dict = {

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -12,16 +12,16 @@ class UtilsTestCase(unittest.TestCase):
     def test_get_size_in_gb(self, size_in_bytes, expected):
         self.assertEqual(expected, ix_utils.get_size_in_gb(size_in_bytes))
 
-    @ddt.data(("123456-123456-abcdef-abcdef-abcdef", "iqn", "volume-123456"),
-              ("234567-234567-abcdef-abcdef-abcdef", "iqn", "volume-234567"))
+    @ddt.data(("123456-123456-abcdef-abcdef-abcdef", "iqn", "volume-123456-123456-abcdef-abcdef-abcdef"),
+              ("234567-234567-abcdef-abcdef-abcdef", "iqn", "volume-234567-234567-abcdef-abcdef-abcdef"))
     @ddt.unpack
     def test_generate_freenas_volume_name(self, name, iqn_prefix, expected):
         self.assertEqual(expected,
                          ix_utils.generate_freenas_volume_name(
                              name, iqn_prefix)['name'])
 
-    @ddt.data(("123456-123456-abcdef-abcdef-abcdef", "iqn", "snap-123456-1111-11-11-11-11"),
-              ("234567-234567-abcdef-abcdef-abcdef", "iqn", "snap-234567-1111-11-11-11-11"))
+    @ddt.data(("123456-123456-abcdef-abcdef-abcdef", "iqn", "snap-123456-123456-abcdef-abcdef-abcdef-1111-11-11-11-11"),
+              ("234567-234567-abcdef-abcdef-abcdef", "iqn", "snap-234567-234567-abcdef-abcdef-abcdef-1111-11-11-11-11"))
     @ddt.unpack
     def test_generate_freenas_snapshot_name(self, name, iqn_prefix, expected):
         self.assertEqual(expected, ix_utils.generate_freenas_snapshot_name(


### PR DESCRIPTION
#42 Issue descriptions:

Driver feature manage/unmanage volume/snapshot from Truenas internal reference not yet supported

Failed tempest ci test case
https://docs.openstack.org/tempest/latest/_modules/volume/admin/test_snapshot_manage.html#SnapshotManageAdminTest
https://docs.openstack.org/tempest/latest/_modules/volume/admin/test_volume_manage.html#VolumeManageAdminTest.test_unmanage_manage_volume

Solution:
Adding driver implementation method to to support cinder manage/unmanage volume/snapshot

Changes:
iscsi.py
add functions:
manage_existing
manage_existing_snapshot
manage_existing_get_size
manage_existing_snapshot_get_size
get_manageable_volumes
get_manageable_snapshots

common.py
add function
get_volume
get_snapshot
get_all_snapshot
get_volume_from_snapshot

utils.py
add function
generate_volume_id_from_freenas_volume_name
generate_snapshot_id_from_freenas_snapshot_name

Additional notes:
1. change cinder volume name to truenas zvol name mapping from uuid aaa-bbb-ccc-ddd-eee -> volume-aaa to volume-aaa-bbb-ccc-ddd-eee (this is ensure 1 to 1 mapping so no extra meta storage is required when manage/unmanage two system cinder vs truenas)
2. change cinder snapshot name to truenas zvol name mapping from uuid aaa-bbb-ccc-ddd-eee -> snap-aaa to snap-aaa-bbb-ccc-ddd-eee
3. manage_existing depends on renaming volume from old to new name, use replication api as workaround
4. manage_existing_snapshot depends on renaming snapshot from old name to new name, no api available at this moment, leave for future implementation once rename snapshot name api available or use zfs native command zfs rename instead
5. https://docs.openstack.org/tempest/latest/_modules/volume/admin/test_volume_manage.html#VolumeManageAdminTest.test_unmanage_manage_volume test pass
https://docs.openstack.org/tempest/latest/_modules/volume/admin/test_snapshot_manage.html#SnapshotManageAdminTest test failed due to no snapshot rename implemented for now 
7. get_manageable_volumes and get_manageable_snapshots is not covered by tempest testcase and it's not mandatory leave it for future implementation.
